### PR TITLE
TraCIBuffer: simplify read and write operations

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIBuffer.cc
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.cc
@@ -75,10 +75,4 @@ template<> TraCICoord TraCIBuffer::read() {
 	return p;
 }
 
-bool isBigEndian() {
-	short a = 0x0102;
-	unsigned char *p_a = reinterpret_cast<unsigned char*>(&a);
-	return (p_a[0] == 0x01);
-}
-
 }

--- a/src/veins/modules/mobility/traci/TraCIBuffer.h
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.h
@@ -49,7 +49,7 @@ class TraCIBuffer {
 
 			if (buf_index + sizeof(output) <= buf.length()) {
 				for (size_t i = 0; i < sizeof(output); ++i) {
-					output.uint <<= 8;
+					if (sizeof(T) > 1) output.uint <<= 8;
 					output.uint |= buf[buf_index++] & 0xff;
 				}
 			}
@@ -71,7 +71,7 @@ class TraCIBuffer {
 			std::string::reverse_iterator it = buf.rbegin();
 			for (size_t i = 0; i < sizeof(input); ++i) {
 				*it++ = static_cast<uint8_t>(input.uint);
-				input.uint >>= 8;
+				if (sizeof(T) > 1) input.uint >>= 8;
 			}
 		}
 


### PR DESCRIPTION
Eliminate branches depending on byte order. One code path relying on shift operations is enough.
