### PR TITLE
add missing simtime header

### DIFF
--- a/src/veins/modules/utility/Consts80211p.h
+++ b/src/veins/modules/utility/Consts80211p.h
@@ -22,6 +22,7 @@
 #define CONSTANTS_802_11p
 
 #include <stdint.h>
+#include <simtime_t.h>
 
 /** @brief Bit rates for 802.11p
  *


### PR DESCRIPTION
Compilation fails in some constellations because type SimTime is used in Const80211p.h, but corresponding header file is never included (explicitly).