### PR TITLE
Omnetpp5b2

### DIFF
--- a/src/veins/base/connectionManager/BaseConnectionManager.cc
+++ b/src/veins/base/connectionManager/BaseConnectionManager.cc
@@ -8,7 +8,7 @@
 #include "veins/base/utils/FindModule.h"
 
 #ifndef ccEV
-#define ccEV (ev.isDisabled()||!coreDebug) ? ev : ev << getName() << ": "
+#define ccEV (getEnvir()->isDisabled()||!coreDebug) ? EV : EV << getName() << ": "
 #endif
 
 namespace {

--- a/src/veins/base/connectionManager/ChannelAccess.cc
+++ b/src/veins/base/connectionManager/ChannelAccess.cc
@@ -34,6 +34,7 @@
 #include "veins/base/modules/BaseWorldUtility.h"
 #include "veins/base/connectionManager/BaseConnectionManager.h"
 
+#include <omnetpp.h>
 using std::endl;
 
 const simsignalwrap_t ChannelAccess::mobilityStateChangedSignal = simsignalwrap_t(MIXIM_SIGNAL_MOBILITY_CHANGE_NAME);

--- a/src/veins/base/connectionManager/ChannelAccess.cc
+++ b/src/veins/base/connectionManager/ChannelAccess.cc
@@ -45,7 +45,7 @@ BaseConnectionManager* ChannelAccess::getConnectionManager(cModule* nic)
 						 ? nic->par("connectionManagerName").stringValue()
 						 : "";
 	if (cmName != ""){
-		cModule* ccModule = simulation.getModuleByPath(cmName.c_str());
+		cModule* ccModule = cSimulation::getActiveSimulation()->getModuleByPath(cmName.c_str());
 
 		return dynamic_cast<BaseConnectionManager *>(ccModule);
 	}

--- a/src/veins/base/connectionManager/ConnectionManager.cc
+++ b/src/veins/base/connectionManager/ConnectionManager.cc
@@ -5,7 +5,7 @@
 #include "veins/base/modules/BaseWorldUtility.h"
 
 #ifndef ccEV
-#define ccEV (ev.isDisabled()||!coreDebug) ? ev : ev << getName() << ": "
+#define ccEV (getEnvir()->isDisabled()||!coreDebug) ? EV : EV << getName() << ": "
 #endif
 
 Define_Module( ConnectionManager );

--- a/src/veins/base/connectionManager/NicEntryDebug.cc
+++ b/src/veins/base/connectionManager/NicEntryDebug.cc
@@ -80,7 +80,7 @@ int NicEntryDebug::collectGates(const char* pattern, GateStack& gates)
 	{
 		cGate* hostGate = host->gate(gateName);
 		if(hostGate->isConnectedOutside()) {
-			opp_error("Gate %s is still connected but not registered with this "
+			throw new cException("Gate %s is still connected but not registered with this "
 					  "NicEntry. Either the last NicEntry for this NIC did not "
 					  "clean up correctly or another gate creation module is "
 					  "interfering with this one!", gateName);

--- a/src/veins/base/connectionManager/NicEntryDebug.cc
+++ b/src/veins/base/connectionManager/NicEntryDebug.cc
@@ -27,7 +27,7 @@
 #include "veins/base/utils/FindModule.h"
 
 #ifndef nicEV
-#define nicEV (ev.isDisabled()||!coreDebug) ? ev : ev << "NicEntry: "
+#define nicEV (getEnvir()->isDisabled()||!coreDebug) ? EV : EV << "NicEntry: "
 #endif
 
 using std::endl;

--- a/src/veins/base/connectionManager/NicEntryDirect.cc
+++ b/src/veins/base/connectionManager/NicEntryDirect.cc
@@ -24,7 +24,7 @@
 #include "veins/base/connectionManager/ChannelAccess.h"
 
 #ifndef nicEV
-#define nicEV (ev.isDisabled()||!coreDebug) ? ev : ev << "NicEntry: "
+#define nicEV (getEnvir()->isDisabled()||!coreDebug) ? EV : EV << "NicEntry: "
 #endif
 
 using std::endl;

--- a/src/veins/base/modules/BaseApplLayer.h
+++ b/src/veins/base/modules/BaseApplLayer.h
@@ -127,14 +127,14 @@ protected:
 	 */
 	virtual void handleUpperMsg(cMessage *msg) {
 		assert(false);
-		opp_error("Application has no upper layers!");
+		throw new cException("Application has no upper layers!");
 		delete msg;
 	}
 
 	/** @brief Handle control messages from upper layer */
 	virtual void handleUpperControl(cMessage *msg) {
 		assert(false);
-		opp_error("Application has no upper layers!");
+		throw new cException("Application has no upper layers!");
 		delete msg;
 	}
 

--- a/src/veins/base/modules/BaseLayer.cc
+++ b/src/veins/base/modules/BaseLayer.cc
@@ -96,14 +96,14 @@ void BaseLayer::handleMessage(cMessage* msg)
          * it would be wrong to forward the message to one of these gates,
          * as they actually don't exist, so raise an error instead.
          */
-        opp_error("No self message and no gateID?? Check configuration.");
+        throw new cException("No self message and no gateID?? Check configuration.");
     } else {
         /* msg->getArrivalGateId() should be valid, but it isn't recognized
          * here. This could signal the case that this class is extended
          * with extra gates, but handleMessage() isn't overridden to
          * check for the new gate(s).
          */
-        opp_error("Unknown gateID?? Check configuration or override handleMessage().");
+        throw new cException("Unknown gateID?? Check configuration or override handleMessage().");
     }
 }
 

--- a/src/veins/base/modules/BaseMobility.cc
+++ b/src/veins/base/modules/BaseMobility.cc
@@ -283,7 +283,7 @@ void BaseMobility::updatePosition() {
     //publish the the new move
     emit(mobilityStateChangedSignal, this);
 
-    if(ev.isGUI())
+    if(getEnvir()->isGUI())
     {
     	std::ostringstream osDisplayTag;
 #ifdef __APPLE__

--- a/src/veins/base/modules/BaseModule.cc
+++ b/src/veins/base/modules/BaseModule.cc
@@ -59,7 +59,7 @@ void BaseModule::receiveSignal(cComponent *source, simsignal_t signalID, cObject
 			handleHostState(*pHostState);
 		}
 		else {
-			opp_warning("Got catHostStateSignal but obj was not a HostState pointer?");
+			throw new cException("Got catHostStateSignal but obj was not a HostState pointer?");
 		}
 	}
 }

--- a/src/veins/base/modules/BaseModule.h
+++ b/src/veins/base/modules/BaseModule.h
@@ -29,13 +29,13 @@
 #include "veins/base/utils/HostState.h"
 
 #ifndef debugEV
-#define debugEV_clear (ev.isDisabled()||!debug) ? ev : ev
-#define debugEV (ev.isDisabled()||!debug) ? ev : ev << logName() << "::" << getClassName() << ": "
+#define debugEV_clear (getEnvir()->isDisabled()||!debug) ? EV : EV
+#define debugEV (getEnvir()->isDisabled()||!debug) ? EV : EV << logName() << "::" << getClassName() << ": "
 #endif
 
 #ifndef coreEV
-#define coreEV_clear (ev.isDisabled()||!coreDebug) ? ev : ev
-#define coreEV (ev.isDisabled()||!coreDebug) ? ev : ev << logName() << "::" << getClassName() <<": "
+#define coreEV_clear (getEnvir()->isDisabled()||!coreDebug) ? EV : EV
+#define coreEV (getEnvir()->isDisabled()||!coreDebug) ? EV : EV << logName() << "::" << getClassName() <<": "
 #endif
 
 /**

--- a/src/veins/base/modules/BaseWorldUtility.cc
+++ b/src/veins/base/modules/BaseWorldUtility.cc
@@ -55,15 +55,15 @@ void BaseWorldUtility::initializeIfNecessary()
                                use2DFlag ? 0. : par("playgroundSizeZ").doubleValue());
 
 	if(playgroundSize.x < 0) {
-		opp_error("Playground size in X direction is invalid: "\
+		throw new cException("Playground size in X direction is invalid: "\
 				  "(%f). Should be greater than or equal to zero.", playgroundSize.x);
 	}
 	if(playgroundSize.y < 0) {
-		opp_error("Playground size in Y direction is invalid: "\
+		throw new cException("Playground size in Y direction is invalid: "\
 				  "(%f). Should be greater than or equal to zero.", playgroundSize.y);
 	}
 	if(!use2DFlag && playgroundSize.z < 0) {
-		opp_error("Playground size in Z direction is invalid: "\
+		throw new cException("Playground size in Z direction is invalid: "\
 				  "(%f). Should be greater than or equal to zero.", playgroundSize.z);
 	}
 

--- a/src/veins/base/modules/BaseWorldUtility.cc
+++ b/src/veins/base/modules/BaseWorldUtility.cc
@@ -39,7 +39,7 @@ void BaseWorldUtility::initialize(int stage) {
 		//check if necessary modules are there
 		//Connection Manager
 		if(!FindModule<BaseConnectionManager*>::findGlobalModule()) {
-			opp_warning("Could not find a connection manager module in the network!");
+			throw new cException("Could not find a connection manager module in the network!");
 		}
 	}
 }

--- a/src/veins/base/modules/BaseWorldUtility.h
+++ b/src/veins/base/modules/BaseWorldUtility.h
@@ -107,7 +107,7 @@ public:
     	// if counter has done one complete cycle and will be set to a value it already had
     	if (airFrameId == -1){
     		// print a warning
-    		ev << "WARNING: AirFrameId-Counter has done one complete cycle."
+    		EV << "WARNING: AirFrameId-Counter has done one complete cycle."
     		<< " AirFrameIds are repeating now and may not be unique anymore." << endl;
     	}
 

--- a/src/veins/base/modules/BatteryAccess.cc
+++ b/src/veins/base/modules/BatteryAccess.cc
@@ -25,7 +25,7 @@ void BatteryAccess::registerWithBattery(const std::string& name, int numAccounts
 	battery = FindModule<BaseBattery*>::findSubModule(findHost());
 
 	if(!battery) {
-		opp_warning("No battery module defined!");
+		throw new cException("No battery module defined!");
 	} else {
 		deviceID = battery->registerDevice(name, numAccounts);
 	}

--- a/src/veins/base/phyLayer/BaseDecider.cc
+++ b/src/veins/base/phyLayer/BaseDecider.cc
@@ -76,7 +76,7 @@ simtime_t BaseDecider::processSignalEnd(AirFrame* frame) {
 }
 
 simtime_t BaseDecider::processUnknownSignal(AirFrame* frame) {
-	opp_error("Unknown state for the AirFrame with ID %d", frame->getId());
+	throw new cException("Unknown state for the AirFrame with ID %d", frame->getId());
 	return notAgain;
 }
 
@@ -100,7 +100,7 @@ simtime_t BaseDecider::handleChannelSenseRequest(ChannelSenseRequest* request) {
 	}
 
 	if (currentChannelSenseRequest.first != request) {
-		opp_error("Got a new ChannelSenseRequest while already handling another one!");
+		throw new cException("Got a new ChannelSenseRequest while already handling another one!");
 		return notAgain;
 	}
 

--- a/src/veins/base/phyLayer/BaseDecider.h
+++ b/src/veins/base/phyLayer/BaseDecider.h
@@ -185,7 +185,7 @@ protected:
 	 * Default implementation does not handle signal headers.
 	 */
 	virtual simtime_t processSignalHeader(AirFrame* frame) {
-		opp_error("BaseDecider does not handle Signal headers!");
+		throw new cException("BaseDecider does not handle Signal headers!");
 		return notAgain;
 	}
 

--- a/src/veins/base/phyLayer/BaseDecider.h
+++ b/src/veins/base/phyLayer/BaseDecider.h
@@ -15,7 +15,7 @@ class Mapping;
 
 using Veins::AirFrame;
 
-#define deciderEV (ev.isDisabled()||!debug) ? ev : ev << "[Host " << myIndex << "] - PhyLayer(Decider): "
+#define deciderEV (getEnvir()->isDisabled()||!debug) ? EV : EV << "[Host " << myIndex << "] - PhyLayer(Decider): "
 
 /**
  * @brief Provides some base functionality for most common deciders.

--- a/src/veins/base/phyLayer/BasePhyLayer.cc
+++ b/src/veins/base/phyLayer/BasePhyLayer.cc
@@ -84,12 +84,12 @@ void BasePhyLayer::initialize(int stage) {
 		// get pointer to the world module
 		world = FindModule<BaseWorldUtility*>::findGlobalModule();
         if (world == NULL) {
-            opp_error("Could not find BaseWorldUtility module");
+            throw new cException("Could not find BaseWorldUtility module");
         }
 
         if(cc->hasPar("sat")
 		   && (sensitivity - FWMath::dBm2mW(cc->par("sat").doubleValue())) < -0.000001) {
-            opp_error("Sensitivity can't be smaller than the "
+            throw new cException("Sensitivity can't be smaller than the "
 					  "signal attenuation threshold (sat) in ConnectionManager. "
 					  "Please adjust your omnetpp.ini file accordingly.");
 		}
@@ -195,19 +195,19 @@ void BasePhyLayer::initializeDecider(cXMLElement* xmlConfig) {
 	decider = 0;
 
 	if(xmlConfig == 0) {
-		opp_error("No decider configuration file specified.");
+		throw new cException("No decider configuration file specified.");
 		return;
 	}
 
 	cXMLElementList deciderList = xmlConfig->getElementsByTagName("Decider");
 
 	if(deciderList.empty()) {
-		opp_error("No decider configuration found in configuration file.");
+		throw new cException("No decider configuration found in configuration file.");
 		return;
 	}
 
 	if(deciderList.size() > 1) {
-		opp_error("More than one decider configuration found in configuration file.");
+		throw new cException("More than one decider configuration found in configuration file.");
 		return;
 	}
 
@@ -216,7 +216,7 @@ void BasePhyLayer::initializeDecider(cXMLElement* xmlConfig) {
 	const char* name = deciderData->getAttribute("type");
 
 	if(name == 0) {
-		opp_error("Could not read type of decider from configuration file.");
+		throw new cException("Could not read type of decider from configuration file.");
 		return;
 	}
 
@@ -226,7 +226,7 @@ void BasePhyLayer::initializeDecider(cXMLElement* xmlConfig) {
 	decider = getDeciderFromName(name, params);
 
 	if(decider == 0) {
-		opp_error("Could not find a decider with the name \"%s\".", name);
+		throw new cException("Could not find a decider with the name \"%s\".", name);
 		return;
 	}
 
@@ -368,7 +368,7 @@ void BasePhyLayer::handleAirFrame(AirFrame* frame) {
 		break;
 
 	default:
-		opp_error( "Unknown AirFrame state: %s", frame->getState());
+		throw new cException( "Unknown AirFrame state: %s", frame->getState());
 		break;
 	}
 }
@@ -432,7 +432,7 @@ void BasePhyLayer::handleAirFrameReceiving(AirFrame* frame) {
 
 	//invalid point in time
 	} else if(nextHandleTime < simTime() || nextHandleTime > signalEndTime) {
-		opp_error("Invalid next handle time returned by Decider. Expected a value between current simulation time (%.2f) and end of signal (%.2f) but got %.2f",
+		throw new cException("Invalid next handle time returned by Decider. Expected a value between current simulation time (%.2f) and end of signal (%.2f) but got %.2f",
 								SIMTIME_DBL(simTime()), SIMTIME_DBL(signalEndTime), SIMTIME_DBL(nextHandleTime));
 	}
 
@@ -466,7 +466,7 @@ void BasePhyLayer::handleUpperMessage(cMessage* msg){
 	{
         delete msg;
         msg = 0;
-		opp_error("Error: message for sending received, but radio not in state TX");
+		throw new cException("Error: message for sending received, but radio not in state TX");
 	}
 
 	// check if not already sending
@@ -474,7 +474,7 @@ void BasePhyLayer::handleUpperMessage(cMessage* msg){
 	{
         delete msg;
         msg = 0;
-		opp_error("Error: message for sending received, but radio already sending");
+		throw new cException("Error: message for sending received, but radio already sending");
 	}
 
 	// build the AirFrame to send
@@ -554,7 +554,7 @@ void BasePhyLayer::handleChannelSenseRequest(cMessage* msg) {
 			channelInfo.startRecording(simTime());
 		}
 	} else if(nextHandleTime >= 0.0){
-		opp_error("Next handle time of ChannelSenseRequest returned by the Decider is smaller then current simulation time: %.2f",
+		throw new cException("Next handle time of ChannelSenseRequest returned by the Decider is smaller then current simulation time: %.2f",
 				SIMTIME_DBL(nextHandleTime));
 	}
 

--- a/src/veins/base/phyLayer/BasePhyLayer.cc
+++ b/src/veins/base/phyLayer/BasePhyLayer.cc
@@ -150,7 +150,7 @@ void BasePhyLayer::getParametersFromXML(cXMLElement* xmlData, ParameterMap& outp
 		const char* type = (*it)->getAttribute("type");
 		const char* value = (*it)->getAttribute("value");
 		if(name == 0 || type == 0 || value == 0) {
-			ev << "Invalid parameter, could not find name, type or value." << endl;
+			EV << "Invalid parameter, could not find name, type or value." << endl;
 			continue;
 		}
 
@@ -173,7 +173,7 @@ void BasePhyLayer::getParametersFromXML(cXMLElement* xmlData, ParameterMap& outp
 			param.setLongValue(strtol(value, 0, 0));
 
 		} else {
-			ev << "Unknown parameter type: \"" << sType << "\"" << endl;
+			EV << "Unknown parameter type: \"" << sType << "\"" << endl;
 			continue;
 		}
 
@@ -345,7 +345,7 @@ void BasePhyLayer::handleMessage(cMessage* msg) {
 
 	//unknown message
 	} else {
-		ev << "Unknown message received." << endl;
+		EV << "Unknown message received." << endl;
 		delete msg;
 	}
 }
@@ -569,7 +569,7 @@ void BasePhyLayer::handleUpperControlMessage(cMessage* msg){
 		handleChannelSenseRequest(msg);
 		break;
 	default:
-		ev << "Received unknown control message from upper layer!" << endl;
+		EV << "Received unknown control message from upper layer!" << endl;
 		break;
 	}
 }

--- a/src/veins/base/phyLayer/BasePhyLayer.cc
+++ b/src/veins/base/phyLayer/BasePhyLayer.cc
@@ -255,7 +255,7 @@ void BasePhyLayer::initializeAnalogueModels(cXMLElement* xmlConfig) {
 
 	if(newAnalogueModel == 0)
 	{
-		opp_warning("Could not find an analogue model with the name \"%s\".", s.c_str());
+		throw new cException("Could not find an analogue model with the name \"%s\".", s.c_str());
 	}
 	else
 	{
@@ -264,14 +264,14 @@ void BasePhyLayer::initializeAnalogueModels(cXMLElement* xmlConfig) {
 
 
 	if(xmlConfig == 0) {
-		opp_warning("No analogue models configuration file specified.");
+		throw new cException("No analogue models configuration file specified.");
 		return;
 	}
 
 	cXMLElementList analogueModelList = xmlConfig->getElementsByTagName("AnalogueModel");
 
 	if(analogueModelList.empty()) {
-		opp_warning("No analogue models configuration found in configuration file.");
+		throw new cException("No analogue models configuration found in configuration file.");
 		return;
 	}
 
@@ -286,7 +286,7 @@ void BasePhyLayer::initializeAnalogueModels(cXMLElement* xmlConfig) {
 		const char* name = analogueModelData->getAttribute("type");
 
 		if(name == 0) {
-			opp_warning("Could not read name of analogue model.");
+			throw new cException("Could not read name of analogue model.");
 			continue;
 		}
 
@@ -296,7 +296,7 @@ void BasePhyLayer::initializeAnalogueModels(cXMLElement* xmlConfig) {
 		AnalogueModel* newAnalogueModel = getAnalogueModelFromName(name, params);
 
 		if(newAnalogueModel == 0) {
-			opp_warning("Could not find an analogue model with the name \"%s\".", name);
+			throw new cException("Could not find an analogue model with the name \"%s\".", name);
 			continue;
 		}
 
@@ -732,7 +732,7 @@ simtime_t BasePhyLayer::setRadioState(int rs) {
 	assert(radio);
 
 	if(txOverTimer && txOverTimer->isScheduled()) {
-		opp_warning("Switched radio while sending an AirFrame. The effects this would have on the transmission are not simulated by the BasePhyLayer!");
+		throw new cException("Switched radio while sending an AirFrame. The effects this would have on the transmission are not simulated by the BasePhyLayer!");
 	}
 
 	simtime_t switchTime = radio->switchTo(rs, simTime());
@@ -770,7 +770,7 @@ int BasePhyLayer::getPhyHeaderLength() {
 
 void BasePhyLayer::setCurrentRadioChannel(int newRadioChannel) {
 	if(txOverTimer && txOverTimer->isScheduled()) {
-		opp_warning("Switched channel while sending an AirFrame. The effects this would have on the transmission are not simulated by the BasePhyLayer!");
+		throw new cException("Switched channel while sending an AirFrame. The effects this would have on the transmission are not simulated by the BasePhyLayer!");
 	}
 
 	radio->setCurrentChannel(newRadioChannel);

--- a/src/veins/base/phyLayer/BasePhyLayer.cc
+++ b/src/veins/base/phyLayer/BasePhyLayer.cc
@@ -1,6 +1,6 @@
 #include "veins/base/phyLayer/BasePhyLayer.h"
 
-#include <cxmlelement.h>
+#include <omnetpp/cxmlelement.h>
 
 #include "veins/base/phyLayer/MacToPhyControlInfo.h"
 #include "veins/base/phyLayer/PhyToMacControlInfo.h"

--- a/src/veins/base/phyLayer/BasePhyLayer.h
+++ b/src/veins/base/phyLayer/BasePhyLayer.h
@@ -15,7 +15,6 @@
 class AnalogueModel;
 class Decider;
 class BaseWorldUtility;
-class cXMLElement;
 
 using Veins::AirFrame;
 using Veins::ChannelAccess;

--- a/src/veins/base/phyLayer/Signal_.h
+++ b/src/veins/base/phyLayer/Signal_.h
@@ -250,7 +250,7 @@ public:
 	 * has not been sent/received yet, or if the module was deleted
 	 * in the meantime.
 	 */
-	cModule *getReceptionModule() const {return receiverModuleID < 0 ? NULL : simulation.getModule(receiverModuleID);}
+	cModule *getReceptionModule() const {return receiverModuleID < 0 ? NULL : getSimulation()->getModule(receiverModuleID);}
 
 	/**
 	 * Returns pointers to the gate from which the signal was sent and
@@ -264,7 +264,7 @@ public:
 	 * has not been sent/received yet, or if the sender module got deleted
 	 * in the meantime.
 	 */
-	cModule *getSendingModule() const {return senderModuleID < 0 ? NULL : simulation.getModule(senderModuleID);}
+	cModule *getSendingModule() const {return senderModuleID < 0 ? NULL : getSimulation()->getModule(senderModuleID);}
 
 	/**
 	 * Returns pointers to the gate from which the signal was sent and

--- a/src/veins/base/utils/FindModule.h
+++ b/src/veins/base/utils/FindModule.h
@@ -41,7 +41,7 @@ class FindModule
 		 *
 		 * Returns NULL if no module of this type could be found.
 		 */
-		static T findGlobalModule() {return findSubModule(simulation.getSystemModule());}
+		static T findGlobalModule() {return findSubModule(getSimulation()->getSystemModule());}
 
 		/**
 		 * @brief Returns a pointer to the host module of the passed module.
@@ -92,7 +92,7 @@ class AccessModuleWrap
 		T *const get(cModule *const from = NULL)
 		{
 			if (!pModule) {
-				pModule = FindModule<T*>::findSubModule( FindModule<>::findHost(from != NULL ? from : simulation.getContextModule()) );
+				pModule = FindModule<T*>::findSubModule( FindModule<>::findHost(from != NULL ? from : getSimulation()->getContextModule()) );
 			}
 			return pModule;
 		}

--- a/src/veins/base/utils/MiXiMDefs.h
+++ b/src/veins/base/utils/MiXiMDefs.h
@@ -19,6 +19,7 @@
 #define __MIXIM_MIXIMDEFS_H
 
 #include <omnetpp.h>
+#include <omnetpp/clistener.h>
 #include "veins/base/utils/miximkerneldefs.h"
 
 #if defined(MIXIM_EXPORT)

--- a/src/veins/base/utils/PassedMessage.h
+++ b/src/veins/base/utils/PassedMessage.h
@@ -30,7 +30,7 @@ class MIXIM_API PassedMessage : public cObject {
         case LOWER_DATA: s = "LOWER_DATA"; break;
         case LOWER_CONTROL: s = "LOWER_CONTROL"; break;
         default:
-            opp_error("PassedMessage::gateToString: got invalid value");
+            throw new cException("PassedMessage::gateToString: got invalid value");
             s = 0;
             break;
         }

--- a/src/veins/modules/analogueModel/BreakpointPathlossModel.cc
+++ b/src/veins/modules/analogueModel/BreakpointPathlossModel.cc
@@ -4,7 +4,7 @@
 
 using Veins::AirFrame;
 
-#define debugEV (ev.isDisabled()||!debug) ? ev : ev << "PhyLayer(BreakpointPathlossModel): "
+#define debugEV (getEnvir()->isDisabled()||!debug) ? EV : EV << "PhyLayer(BreakpointPathlossModel): "
 
 
 void BreakpointPathlossModel::filterSignal(AirFrame *frame, const Coord& sendersPos, const Coord& receiverPos) {

--- a/src/veins/modules/analogueModel/JakesFading.cc
+++ b/src/veins/modules/analogueModel/JakesFading.cc
@@ -77,8 +77,8 @@ JakesFading::JakesFading(int fadingPaths, simtime_t_cref delayRMS,
 	delay = new simtime_t[fadingPaths];
 
 	for (int i = 0; i < fadingPaths; i++) {
-		angleOfArrival[i] = cos(uniform(0, M_PI));
-		delay[i] = exponential(delayRMS);
+		angleOfArrival[i] = cos(uniform(getEnvir()->getRNG(0), 0, M_PI)); //TODO verify this works correctly! This constructs a cRandom with the default rng (=0), which is the same as uniform(0, M_PI), i.e., the third argument, which was 0 by default in older versions
+		delay[i] = exponential(getEnvir()->getRNG(0), delayRMS.dbl());
 	}
 }
 

--- a/src/veins/modules/analogueModel/LogNormalShadowing.cc
+++ b/src/veins/modules/analogueModel/LogNormalShadowing.cc
@@ -27,7 +27,7 @@ LogNormalShadowing::LogNormalShadowing(double mean, double stdDev, simtime_t_cre
 LogNormalShadowing::~LogNormalShadowing() {}
 
 double LogNormalShadowing::randomLogNormalGain() const {
-	return FWMath::dBm2mW(-1.0 * normal(mean, stdDev));
+	return FWMath::dBm2mW(-1.0 * normal(getEnvir()->getRNG(0), mean, stdDev));
 }
 
 void LogNormalShadowing::filterSignal(AirFrame *frame, const Coord& sendersPos, const Coord& receiverPos) {

--- a/src/veins/modules/analogueModel/PERModel.cc
+++ b/src/veins/modules/analogueModel/PERModel.cc
@@ -10,7 +10,7 @@ void PERModel::filterSignal(AirFrame *frame, const Coord& sendersPos, const Coor
 	//simtime_t end    = signal.getReceptionEnd();
 
 	double attenuationFactor = 1;  // no attenuation
-	if(packetErrorRate > 0 && uniform(0, 1) < packetErrorRate) {
+	if(packetErrorRate > 0 && uniform(getEnvir()->getRNG(0), 0, 1) < packetErrorRate) {
 		attenuationFactor = 0;  // absorb all energy so that the receveir cannot receive anything
 	}
 

--- a/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
+++ b/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
@@ -35,7 +35,7 @@ SimpleObstacleShadowing::SimpleObstacleShadowing(ObstacleControl& obstacleContro
 	playgroundSize(playgroundSize),
 	debug(debug)
 {
-	if (useTorus) opp_error("SimpleObstacleShadowing does not work on torus-shaped playgrounds");
+	if (useTorus) throw new cException("SimpleObstacleShadowing does not work on torus-shaped playgrounds");
 }
 
 

--- a/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
+++ b/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
@@ -2,7 +2,7 @@
 
 using Veins::AirFrame;
 
-#define debugEV (ev.isDisabled()||!debug) ? ev : ev << "PhyLayer(SimpleObstacleShadowing): "
+#define debugEV (getEnvir()->isDisabled()||!debug) ? EV : EV << "PhyLayer(SimpleObstacleShadowing): "
 
 #if 0
 SimplePathlossConstMapping::SimplePathlossConstMapping(const DimensionSet& dimensions,

--- a/src/veins/modules/analogueModel/SimplePathlossModel.cc
+++ b/src/veins/modules/analogueModel/SimplePathlossModel.cc
@@ -4,7 +4,7 @@
 
 using Veins::AirFrame;
 
-#define splmEV (ev.isDisabled()||!debug) ? ev : ev << "PhyLayer(SimplePathlossModel): "
+#define splmEV (getEnvir()->isDisabled()||!debug) ? EV : EV << "PhyLayer(SimplePathlossModel): "
 
 SimplePathlossConstMapping::SimplePathlossConstMapping(const DimensionSet& dimensions,
 													   SimplePathlossModel* model,

--- a/src/veins/modules/analogueModel/TwoRayInterferenceModel.cc
+++ b/src/veins/modules/analogueModel/TwoRayInterferenceModel.cc
@@ -23,7 +23,7 @@
 
 using Veins::AirFrame;
 
-#define debugEV (ev.isDisabled()||!debug) ? ev : ev << "PhyLayer(TwoRayInterferenceModel): "
+#define debugEV (getEnvir()->isDisabled()||!debug) ? EV : EV << "PhyLayer(TwoRayInterferenceModel): "
 
 void TwoRayInterferenceModel::filterSignal(AirFrame *frame, const Coord& senderPos, const Coord& receiverPos) {
 	Signal& s = frame->getSignal();

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -88,7 +88,7 @@ void Mac1609_4::initialize(int stage) {
 				case 2: mySCH = Channels::SCH2; break;
 				case 3: mySCH = Channels::SCH3; break;
 				case 4: mySCH = Channels::SCH4; break;
-				default: opp_error("Service Channel must be between 1 and 4"); break;
+				default: throw new cException("Service Channel must be between 1 and 4"); break;
 			}
 		}
 
@@ -328,7 +328,7 @@ void Mac1609_4::handleLowerControl(cMessage* msg) {
 		//don't set the chan to idle. the PHY layer decides, not us.
 
 		if (guardActive()) {
-			opp_error("We shouldnt have sent a packet in guard!");
+			throw new cException("We shouldnt have sent a packet in guard!");
 		}
 	}
 	else if (msg->getKind() == Mac80211pToPhy11pInterface::CHANNEL_BUSY) {
@@ -469,7 +469,7 @@ simtime_t Mac1609_4::timeLeftInSlot() const {
 void Mac1609_4::changeServiceChannel(int cN) {
 	ASSERT(useSCH);
 	if (cN != Channels::SCH1 && cN != Channels::SCH2 && cN != Channels::SCH3 && cN != Channels::SCH4) {
-		opp_error("This Service Channel doesnt exit: %d",cN);
+		throw new cException("This Service Channel doesnt exit: %d",cN);
 	}
 
 	mySCH = cN;
@@ -542,7 +542,7 @@ int Mac1609_4::EDCA::queuePacket(t_access_category ac,WaveShortMessage* msg) {
 int Mac1609_4::EDCA::createQueue(int aifsn, int cwMin, int cwMax,t_access_category ac) {
 
 	if (myQueues.find(ac) != myQueues.end()) {
-		opp_error("You can only add one queue per Access Category per EDCA subsystem");
+		throw new cException("You can only add one queue per Access Category per EDCA subsystem");
 	}
 
 	EDCAQueue newQueue(aifsn,cwMin,cwMax,ac);
@@ -558,7 +558,7 @@ Mac1609_4::t_access_category Mac1609_4::mapPriority(int prio) {
 		case 1: return AC_BE;
 		case 2: return AC_VI;
 		case 3: return AC_VO;
-		default: opp_error("MacLayer received a packet with unknown priority"); break;
+		default: throw new cException("MacLayer received a packet with unknown priority"); break;
 	}
 	return AC_VO;
 }
@@ -596,7 +596,7 @@ WaveShortMessage* Mac1609_4::EDCA::initiateTransmit(simtime_t lastIdle) {
 	}
 
 	if (pktToSend == NULL) {
-		opp_error("No packet was ready");
+		throw new cException("No packet was ready");
 	}
 	return pktToSend;
 }
@@ -794,7 +794,7 @@ void Mac1609_4::channelIdle(bool afterSwitch) {
 		//this rare case can happen when another node's time has such a big offset that the node sent a packet although we already changed the channel
 		//the workaround is not trivial and requires a lot of changes to the phy and decider
 		return;
-		//opp_error("channel turned idle but contention timer was scheduled!");
+		//throw new cException("channel turned idle but contention timer was scheduled!");
 	}
 
 	idleChannel = true;
@@ -841,7 +841,7 @@ void Mac1609_4::setParametersForBitrate(uint64_t bitrate) {
 			return;
 		}
 	}
-	opp_error("Chosen Bitrate is not valid for 802.11p: Valid rates are: 3Mbps, 4.5Mbps, 6Mbps, 9Mbps, 12Mbps, 18Mbps, 24Mbps and 27Mbps. Please adjust your omnetpp.ini file accordingly.");
+	throw new cException("Chosen Bitrate is not valid for 802.11p: Valid rates are: 3Mbps, 4.5Mbps, 6Mbps, 9Mbps, 12Mbps, 18Mbps, 24Mbps and 27Mbps. Please adjust your omnetpp.ini file accordingly.");
 }
 
 

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -25,8 +25,8 @@
 #include "veins/base/phyLayer/PhyToMacControlInfo.h"
 #include "veins/modules/messages/PhyControlMessage_m.h"
 
-#define DBG_MAC EV
-//#define DBG_MAC std::cerr << "[" << simTime().raw() << "] " << myId << " "
+//#define DBG_MAC EV //TODO use this debug environment and/or find a way to define it for Mac1609_4::EDCA
+#define DBG_MAC std::cerr << "[" << simTime().raw() << "] " << myId << " "
 
 Define_Module(Mac1609_4);
 

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -25,8 +25,8 @@
 #include "veins/base/phyLayer/PhyToMacControlInfo.h"
 #include "veins/modules/messages/PhyControlMessage_m.h"
 
-//#define DBG_MAC EV //TODO use this debug environment and/or find a way to define it for Mac1609_4::EDCA
-#define DBG_MAC std::cerr << "[" << simTime().raw() << "] " << myId << " "
+#define DBG_MAC EV
+//#define DBG_MAC std::cerr << "[" << simTime().raw() << "] " << myId << " "
 
 Define_Module(Mac1609_4);
 
@@ -564,6 +564,7 @@ Mac1609_4::t_access_category Mac1609_4::mapPriority(int prio) {
 }
 
 WaveShortMessage* Mac1609_4::EDCA::initiateTransmit(simtime_t lastIdle) {
+  EV_STATICCONTEXT
 
 	//iterate through the queues to return the packet we want to send
 	WaveShortMessage* pktToSend = NULL;
@@ -602,6 +603,7 @@ WaveShortMessage* Mac1609_4::EDCA::initiateTransmit(simtime_t lastIdle) {
 }
 
 simtime_t Mac1609_4::EDCA::startContent(simtime_t idleSince,bool guardActive) {
+  EV_STATICCONTEXT
 
 	DBG_MAC << "Restarting contention." << std::endl;
 
@@ -652,6 +654,7 @@ simtime_t Mac1609_4::EDCA::startContent(simtime_t idleSince,bool guardActive) {
 }
 
 void Mac1609_4::EDCA::stopContent(bool allowBackoff, bool generateTxOp) {
+  EV_STATICCONTEXT
 	//update all Queues
 
 	DBG_MAC << "Stopping Contention at " << simTime().raw() << std::endl;
@@ -706,6 +709,7 @@ void Mac1609_4::EDCA::stopContent(bool allowBackoff, bool generateTxOp) {
 	}
 }
 void Mac1609_4::EDCA::backoff(t_access_category ac) {
+  EV_STATICCONTEXT
 	myQueues[ac].currentBackoff = myMac->intuniform(0,myQueues[ac].cwCur);
 	statsSlotsBackoff += myQueues[ac].currentBackoff;
 	statsNumBackoff++;
@@ -713,6 +717,7 @@ void Mac1609_4::EDCA::backoff(t_access_category ac) {
 }
 
 void Mac1609_4::EDCA::postTransmit(t_access_category ac) {
+  EV_STATICCONTEXT
 	delete myQueues[ac].queue.front();
 	myQueues[ac].queue.pop();
 	myQueues[ac].cwCur = myQueues[ac].cwMin;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -37,6 +37,8 @@
 
 #include "veins/modules/utility/ConstsPhy.h"
 
+class Mac1609_4;
+
 /**
  * @brief
  * Manages timeslots for CCH and SCH listening and sending.
@@ -84,7 +86,7 @@ class Mac1609_4 : public BaseMacLayer,
 						};
 				};
 
-				EDCA(t_channel channelType,int maxQueueLength = 0):numQueues(0),maxQueueSize(maxQueueLength),channelType(channelType) {
+				EDCA(t_channel channelType,Mac1609_4* my_mac,int maxQueueLength = 0): numQueues(0),maxQueueSize(maxQueueLength),channelType(channelType),myMac(my_mac) {
 					statsNumInternalContention = 0;
 					statsNumBackoff = 0;
 					statsSlotsBackoff = 0;
@@ -119,6 +121,7 @@ class Mac1609_4 : public BaseMacLayer,
 
 				/** @brief Id for debug messages */
 				std::string myId;
+        Mac1609_4* myMac;
 		};
 
 	public:

--- a/src/veins/modules/mobility/traci/TraCIBuffer.h
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.h
@@ -4,7 +4,7 @@
 #include <cstddef>
 #include <string>
 
-#include <cexception.h>
+#include <omnetpp/cexception.h>
 
 namespace Veins {
 

--- a/src/veins/modules/mobility/traci/TraCIBuffer.h
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.h
@@ -26,12 +26,12 @@ class TraCIBuffer {
 
 			if (isBigEndian()) {
 				for (size_t i=0; i<sizeof(buf_to_return); ++i) {
-					if (eof()) throw cRuntimeError("Attempted to read past end of byte buffer");
+					if (eof()) throw omnetpp::cRuntimeError("Attempted to read past end of byte buffer");
 					p_buf_to_return[i] = buf[buf_index++];
 				}
 			} else {
 				for (size_t i=0; i<sizeof(buf_to_return); ++i) {
-					if (eof()) throw cRuntimeError("Attempted to read past end of byte buffer");
+					if (eof()) throw omnetpp::cRuntimeError("Attempted to read past end of byte buffer");
 					p_buf_to_return[sizeof(buf_to_return)-1-i] = buf[buf_index++];
 				}
 			}

--- a/src/veins/modules/mobility/traci/TraCIColor.cc
+++ b/src/veins/modules/mobility/traci/TraCIColor.cc
@@ -782,6 +782,6 @@ TraCIColor TraCIColor::fromTkColor(std::string tkColorName) {
 	if (tkColorName == "yellow3")                return TraCIColor(205, 205, 0, 255);
 	if (tkColorName == "yellow4")                return TraCIColor(139, 139, 0, 255);
 	if (tkColorName == "YellowGreen")            return TraCIColor(154, 205, 50, 255);
-	opp_error("unknown color name ", tkColorName.c_str());
+	throw new cException("unknown color name ", tkColorName.c_str());
 	return TraCIColor(255, 0, 0, 255);
 }

--- a/src/veins/modules/mobility/traci/TraCIConnection.cc
+++ b/src/veins/modules/mobility/traci/TraCIConnection.cc
@@ -50,7 +50,7 @@ TraCIConnection::~TraCIConnection() {
 TraCIConnection* TraCIConnection::connect(const char* host, int port) {
 	MYDEBUG << "TraCIScenarioManager connecting to TraCI server" << endl;
 
-	if (initsocketlibonce() != 0) opp_error("Could not init socketlib");
+	if (initsocketlibonce() != 0) throw new cException("Could not init socketlib");
 
 	in_addr addr;
 	struct hostent* host_ent;
@@ -62,7 +62,7 @@ TraCIConnection* TraCIConnection::connect(const char* host, int port) {
 	} else if ((host_ent = gethostbyname(host))) {
 		addr = *((struct in_addr*) host_ent->h_addr_list[0]);
 	} else {
-		opp_error("Invalid TraCI server address: %s", host);
+		throw new cException("Invalid TraCI server address: %s", host);
 		return 0;
 	}
 
@@ -74,10 +74,10 @@ TraCIConnection* TraCIConnection::connect(const char* host, int port) {
 
 	SOCKET* socketPtr = new SOCKET();
 	*socketPtr = ::socket(AF_INET, SOCK_STREAM, 0);
-	if (*socketPtr < 0) opp_error("Could not create socket to connect to TraCI server");
+	if (*socketPtr < 0) throw new cException("Could not create socket to connect to TraCI server");
 
 	if (::connect(*socketPtr, (sockaddr const*) &address, sizeof(address)) < 0) {
-		opp_error("Could not connect to TraCI server. Make sure it is running and not behind a firewall. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
+		throw new cException("Could not connect to TraCI server. Make sure it is running and not behind a firewall. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
 	}
 
 	{
@@ -97,8 +97,8 @@ TraCIBuffer TraCIConnection::query(uint8_t commandId, const TraCIBuffer& buf) {
 	ASSERT(commandResp == commandId);
 	uint8_t result; obuf >> result;
 	std::string description; obuf >> description;
-	if (result == RTYPE_NOTIMPLEMENTED) opp_error("TraCI server reported command 0x%2x not implemented (\"%s\"). Might need newer version.", commandId, description.c_str());
-	if (result == RTYPE_ERR) opp_error("TraCI server reported error executing command 0x%2x (\"%s\").", commandId, description.c_str());
+	if (result == RTYPE_NOTIMPLEMENTED) throw new cException("TraCI server reported command 0x%2x not implemented (\"%s\"). Might need newer version.", commandId, description.c_str());
+	if (result == RTYPE_ERR) throw new cException("TraCI server reported error executing command 0x%2x (\"%s\").", commandId, description.c_str());
 	ASSERT(result == RTYPE_OK);
 	return obuf;
 }
@@ -118,7 +118,7 @@ TraCIBuffer TraCIConnection::queryOptional(uint8_t commandId, const TraCIBuffer&
 }
 
 std::string TraCIConnection::receiveMessage() {
-	if (!socketPtr) opp_error("Not connected to TraCI server");
+	if (!socketPtr) throw new cException("Not connected to TraCI server");
 
 	uint32_t msgLength;
 	{
@@ -129,11 +129,11 @@ std::string TraCIConnection::receiveMessage() {
 			if (receivedBytes > 0) {
 				bytesRead += receivedBytes;
 			} else if (receivedBytes == 0) {
-				opp_error("Connection to TraCI server closed unexpectedly. Check your server's log");
+				throw new cException("Connection to TraCI server closed unexpectedly. Check your server's log");
 			} else {
 				if (sock_errno() == EINTR) continue;
 				if (sock_errno() == EAGAIN) continue;
-				opp_error("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
+				throw new cException("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
 			}
 		}
 		TraCIBuffer(std::string(buf2, sizeof(uint32_t))) >> msgLength;
@@ -149,11 +149,11 @@ std::string TraCIConnection::receiveMessage() {
 			if (receivedBytes > 0) {
 				bytesRead += receivedBytes;
 			} else if (receivedBytes == 0) {
-				opp_error("Connection to TraCI server closed unexpectedly. Check your server's log");
+				throw new cException("Connection to TraCI server closed unexpectedly. Check your server's log");
 			} else {
 				if (sock_errno() == EINTR) continue;
 				if (sock_errno() == EAGAIN) continue;
-				opp_error("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
+				throw new cException("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
 			}
 		}
 	}
@@ -161,7 +161,7 @@ std::string TraCIConnection::receiveMessage() {
 }
 
 void TraCIConnection::sendMessage(std::string buf) {
-	if (!socketPtr) opp_error("Not connected to TraCI server");
+	if (!socketPtr) throw new cException("Not connected to TraCI server");
 
 	{
 		uint32_t msgLength = sizeof(uint32_t) + buf.length();
@@ -175,7 +175,7 @@ void TraCIConnection::sendMessage(std::string buf) {
 			} else {
 				if (sock_errno() == EINTR) continue;
 				if (sock_errno() == EAGAIN) continue;
-				opp_error("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
+				throw new cException("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
 			}
 		}
 	}
@@ -190,7 +190,7 @@ void TraCIConnection::sendMessage(std::string buf) {
 			} else {
 				if (sock_errno() == EINTR) continue;
 				if (sock_errno() == EAGAIN) continue;
-				opp_error("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
+				throw new cException("Connection to TraCI server lost. Check your server's log. Error message: %d: %s", sock_errno(), strerror(sock_errno()));
 			}
 		}
 	}

--- a/src/veins/modules/mobility/traci/TraCIConnection.cc
+++ b/src/veins/modules/mobility/traci/TraCIConnection.cc
@@ -8,8 +8,8 @@
 #include <arpa/inet.h>
 #endif
 
-#include <cenvir.h>
-#include <cexception.h>
+#include <omnetpp/cenvir.h>
+#include <omnetpp/cexception.h>
 #include <algorithm>
 #include <functional>
 

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -227,7 +227,7 @@ void TraCIMobility::changePosition()
 	move.setStart(Coord(nextPos.x, nextPos.y, move.getCurrentPosition().z)); // keep z position
 	move.setDirectionByVector(Coord(cos(angle), -sin(angle)));
 	move.setSpeed(speed);
-	if (ev.isGUI()) updateDisplayString();
+	if (getEnvir()->isGUI()) updateDisplayString();
 	fixIfHostGetsOutside();
 	updatePosition();
 }

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -103,7 +103,7 @@ class ObstacleControlAccess
 		}
 
 		ObstacleControl* getIfExists() {
-			return dynamic_cast<ObstacleControl*>(simulation.getModuleByPath("obstacles"));
+			return dynamic_cast<ObstacleControl*>(getSimulation()->getModuleByPath("obstacles"));
 		}
 };
 }

--- a/src/veins/modules/phy/Decider80211p.cc
+++ b/src/veins/modules/phy/Decider80211p.cc
@@ -294,7 +294,7 @@ enum Decider80211p::PACKET_OK_RESULT Decider80211p::packetOk(double snirMin, dou
 
 	//probability of no bit error in the PLCP header
 
-	double rand = dblrand();
+	double rand = dblrand(getEnvir()->getRNG(0));
 
 	if (!collectCollisionStats) {
 		if (rand > headerNoError)
@@ -320,7 +320,7 @@ enum Decider80211p::PACKET_OK_RESULT Decider80211p::packetOk(double snirMin, dou
 
 	//probability of no bit error in the rest of the packet
 
-	rand = dblrand();
+	rand = dblrand(getEnvir()->getRNG(0));
 
 	if (!collectCollisionStats) {
 		if (rand > packetOkSinr) {

--- a/src/veins/modules/phy/PhyLayer80211p.cc
+++ b/src/veins/modules/phy/PhyLayer80211p.cc
@@ -52,7 +52,7 @@ void PhyLayer80211p::initialize(int stage) {
 	BasePhyLayer::initialize(stage);
 	if (stage == 0) {
 		if (par("headerLength").longValue() != PHY_HDR_TOTAL_LENGTH) {
-		opp_error("The header length of the 802.11p standard is 46bit, please change your omnetpp.ini accordingly by either setting it to 46bit or removing the entry");
+		throw new cException("The header length of the 802.11p standard is 46bit, please change your omnetpp.ini accordingly by either setting it to 46bit or removing the entry");
 		}
 		//erase the RadioStateAnalogueModel
 		analogueModels.erase(analogueModels.begin());
@@ -136,7 +136,7 @@ AnalogueModel* PhyLayer80211p::initializeBreakpointPathlossModel(ParameterMap& p
 		if(cc->hasPar("alpha") && alpha1 < cc->par("alpha").doubleValue())
 		{
 	        // throw error
-			opp_error("TestPhyLayer::createPathLossModel(): alpha can't be smaller than specified in \
+			throw new cException("TestPhyLayer::createPathLossModel(): alpha can't be smaller than specified in \
 	               ConnectionManager. Please adjust your config.xml file accordingly");
 		}
 	}
@@ -159,7 +159,7 @@ AnalogueModel* PhyLayer80211p::initializeBreakpointPathlossModel(ParameterMap& p
 		if(cc->hasPar("alpha") && alpha2 < cc->par("alpha").doubleValue())
 		{
 	        // throw error
-			opp_error("TestPhyLayer::createPathLossModel(): alpha can't be smaller than specified in \
+			throw new cException("TestPhyLayer::createPathLossModel(): alpha can't be smaller than specified in \
 	               ConnectionManager. Please adjust your config.xml file accordingly");
 		}
 	}
@@ -184,7 +184,7 @@ AnalogueModel* PhyLayer80211p::initializeBreakpointPathlossModel(ParameterMap& p
 		if(cc->hasPar("carrierFrequency") && carrierFrequency < cc->par("carrierFrequency").doubleValue())
 		{
 			// throw error
-			opp_error("TestPhyLayer::createPathLossModel(): carrierFrequency can't be smaller than specified in \
+			throw new cException("TestPhyLayer::createPathLossModel(): carrierFrequency can't be smaller than specified in \
 	               ConnectionManager. Please adjust your config.xml file accordingly");
 		}
 	}
@@ -204,7 +204,7 @@ AnalogueModel* PhyLayer80211p::initializeBreakpointPathlossModel(ParameterMap& p
 	}
 
 	if(alpha1 ==-1 || alpha2==-1 || breakpointDistance==-1 || L01==-1 || L02==-1) {
-		opp_error("Undefined parameters for breakpointPathlossModel. Please check your configuration.");
+		throw new cException("Undefined parameters for breakpointPathlossModel. Please check your configuration.");
 	}
 
 	return new BreakpointPathlossModel(L01, L02, alpha1, alpha2, breakpointDistance, carrierFrequency, useTorus, playgroundSize, coreDebug);
@@ -238,7 +238,7 @@ AnalogueModel* PhyLayer80211p::initializeSimplePathlossModel(ParameterMap& param
 		if(cc->hasPar("alpha") && alpha < cc->par("alpha").doubleValue())
 		{
 	        // throw error
-			opp_error("TestPhyLayer::createPathLossModel(): alpha can't be smaller than specified in \
+			throw new cException("TestPhyLayer::createPathLossModel(): alpha can't be smaller than specified in \
 	               ConnectionManager. Please adjust your config.xml file accordingly");
 		}
 	}
@@ -270,7 +270,7 @@ AnalogueModel* PhyLayer80211p::initializeSimplePathlossModel(ParameterMap& param
 		if(cc->hasPar("carrierFrequency") && carrierFrequency < cc->par("carrierFrequency").doubleValue())
 		{
 			// throw error
-			opp_error("TestPhyLayer::createPathLossModel(): carrierFrequency can't be smaller than specified in \
+			throw new cException("TestPhyLayer::createPathLossModel(): carrierFrequency can't be smaller than specified in \
 	               ConnectionManager. Please adjust your config.xml file accordingly");
 		}
 	}
@@ -328,7 +328,7 @@ AnalogueModel* PhyLayer80211p::initializeSimpleObstacleShadowing(ParameterMap& p
 		if(cc->hasPar("carrierFrequency") && carrierFrequency < cc->par("carrierFrequency").doubleValue())
 		{
 			// throw error
-			opp_error("initializeSimpleObstacleShadowing(): carrierFrequency can't be smaller than specified in ConnectionManager. Please adjust your config.xml file accordingly");
+			throw new cException("initializeSimpleObstacleShadowing(): carrierFrequency can't be smaller than specified in ConnectionManager. Please adjust your config.xml file accordingly");
 		}
 	}
 	else // carrierFrequency has not been specified in config.xml
@@ -347,7 +347,7 @@ AnalogueModel* PhyLayer80211p::initializeSimpleObstacleShadowing(ParameterMap& p
 	}
 
 	ObstacleControl* obstacleControlP = ObstacleControlAccess().getIfExists();
-	if (!obstacleControlP) opp_error("initializeSimpleObstacleShadowing(): cannot find ObstacleControl module");
+	if (!obstacleControlP) throw new cException("initializeSimpleObstacleShadowing(): cannot find ObstacleControl module");
 	return new SimpleObstacleShadowing(*obstacleControlP, carrierFrequency, useTorus, playgroundSize, coreDebug);
 }
 

--- a/src/veins/modules/phy/SNRThresholdDecider.cc
+++ b/src/veins/modules/phy/SNRThresholdDecider.cc
@@ -125,7 +125,7 @@ simtime_t SNRThresholdDecider::canAnswerCSR(const CSRInfo& requestInfo) {
 	assert(request);
 
 	if(request->getSenseMode() == UNTIL_TIMEOUT) {
-		opp_error("SNRThresholdDecider received an UNTIL_TIMEOUT ChannelSenseRequest.\n"
+		throw new cException("SNRThresholdDecider received an UNTIL_TIMEOUT ChannelSenseRequest.\n"
 				  "SNRThresholdDecider can only handle UNTIL_IDLE or UNTIL_BUSY requests because it "
 				  "implements only instantaneous sensing where UNTIL_TIMEOUT requests "
 				  "don't make sense. Please refer to ChannelSenseRequests documentation "

--- a/src/veins/modules/world/annotations/AnnotationManager.cc
+++ b/src/veins/modules/world/annotations/AnnotationManager.cc
@@ -327,20 +327,20 @@ void AnnotationManager::show(const Annotation* annotation) {
 
 	if (const Point* o = dynamic_cast<const Point*>(annotation)) {
 
-		if (ev.isGUI()) {
+		if (getEnvir()->isGUI()) {
 			// no corresponding TkEnv representation
 		}
 
 		TraCIScenarioManager* traci = TraCIScenarioManagerAccess().get();
 		if (traci && traci->isConnected()) {
-			std::stringstream nameBuilder; nameBuilder << o->text << " " << ev.getUniqueNumber();
+			std::stringstream nameBuilder; nameBuilder << o->text << " " << getEnvir()->getUniqueNumber();
 			traci->getCommandInterface()->addPoi(nameBuilder.str(), "Annotation", TraCIColor::fromTkColor(o->color), 6, o->pos);
 			annotation->traciPoiIds.push_back(nameBuilder.str());
 		}
 	}
 	else if (const Line* l = dynamic_cast<const Line*>(annotation)) {
 
-		if (ev.isGUI()) {
+		if (getEnvir()->isGUI()) {
 #if OMNETPP_CANVAS_VERSION == 0x20140709
 			cLineFigure* figure = new cLineFigure();
 			figure->setStart(cFigure::Point(l->p1.x, l->p1.y));
@@ -357,7 +357,7 @@ void AnnotationManager::show(const Annotation* annotation) {
 		TraCIScenarioManager* traci = TraCIScenarioManagerAccess().get();
 		if (traci && traci->isConnected()) {
 			std::list<Coord> coords; coords.push_back(l->p1); coords.push_back(l->p2);
-			std::stringstream nameBuilder; nameBuilder << "Annotation" << ev.getUniqueNumber();
+			std::stringstream nameBuilder; nameBuilder << "Annotation" << getEnvir()->getUniqueNumber();
 			traci->getCommandInterface()->addPolygon(nameBuilder.str(), "Annotation", TraCIColor::fromTkColor(l->color), false, 5, coords);
 			annotation->traciLineIds.push_back(nameBuilder.str());
 		}
@@ -366,7 +366,7 @@ void AnnotationManager::show(const Annotation* annotation) {
 
 		ASSERT(p->coords.size() >= 2);
 
-		if (ev.isGUI()) {
+		if (getEnvir()->isGUI()) {
 #if OMNETPP_CANVAS_VERSION == 0x20140709
 			cPolygonFigure* figure = new cPolygonFigure();
 			std::vector<cFigure::Point> points;
@@ -393,7 +393,7 @@ void AnnotationManager::show(const Annotation* annotation) {
 
 		TraCIScenarioManager* traci = TraCIScenarioManagerAccess().get();
 		if (traci && traci->isConnected()) {
-			std::stringstream nameBuilder; nameBuilder << "Annotation" << ev.getUniqueNumber();
+			std::stringstream nameBuilder; nameBuilder << "Annotation" << getEnvir()->getUniqueNumber();
 			traci->getCommandInterface()->addPolygon(nameBuilder.str(), "Annotation", TraCIColor::fromTkColor(p->color), false, 4, p->coords);
 			annotation->traciPolygonsIds.push_back(nameBuilder.str());
 		}


### PR DESCRIPTION
This set of commits patches **most** of VEINS to be compatible to the upcoming OMNeT++ version (5+).
For this set of patches to compile, you'll need to change the OMNeT++ `Makefile.inc`; add the `-DAUTOIMPORT_NAMESPACE` to `CFLAGS_RELEASE` and `CFLAGS_DEBUG`. This automatically adds the `USING_NAMESPACE` and `NAMESPACE_END` macros to the appropriate areas in the VEINS code during compilation (because OMNeT++ now has its own namespace) in a backwards-compatible way. However, this patch also includes a few places where the `omnetpp::` namespace had to be included manually. 

In addition, there is a bug (reported [here](https://groups.google.com/forum/#!topic/omnetpp/ag06IvDhb7o)) in the current beta that prevents `TraCIBuffer.cc` from compiling: to fix it, wait for the next beta or edit `include/omnetpp/simkerneldefs.h` line 56 to include the `omnetpp::` namespace before `cRuntimeError`.

Also, this commit set contains some ugly-ish fixes to get things to compile; see 93352cc and 41ba52f. This mainly relates to ~~how debug output is produced from `Mac1609_4::EDCA` (which doesn't work with the new `EV` macro, see [here](https://groups.google.com/forum/#!topic/omnetpp/zRCLTdmKB5M) for more details) and~~ how random numbers are handled in that class (I might have a fix for that last part later, though).

Finally, the changes to the random number generation in OMNeT++ mean I had to make changes to this fairly critical code, and I haven't tested these parts extensively. They should be correct, assuming the documentation for the old and new versions are correct, though. If you have any regression tests to verify that randomness is still handled correctly, I'd appreciate a suggestion on how to run them.