### PR TITLE
TraCICommandInterface and TraCIConstants updates

### DIFF
--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -212,6 +212,10 @@ void TraCICommandInterface::Trafficlight::setPhaseIndex(int32_t index) {
 	ASSERT(buf.eof());
 }
 
+int TraCICommandInterface::Trafficlight::getPhaseIndex() {
+    return traci->genericGetInt(CMD_GET_TL_VARIABLE, trafficLightId, TL_CURRENT_PHASE, RESPONSE_GET_TL_VARIABLE);
+}
+	
 std::list<std::string> TraCICommandInterface::getPolygonIds() {
 	return genericGetStringList(CMD_GET_POLYGON_VARIABLE, "", ID_LIST, RESPONSE_GET_POLYGON_VARIABLE);
 }
@@ -314,6 +318,14 @@ double TraCICommandInterface::Lane::getMeanSpeed() {
 	return traci->genericGetDouble(CMD_GET_LANE_VARIABLE, laneId, LAST_STEP_MEAN_SPEED, RESPONSE_GET_LANE_VARIABLE);
 }
 
+std::list<std::string> TraCICommandInterface::getLaneAreaDetectorIds() {
+    return genericGetStringList(CMD_GET_LANEAREA_VARIABLE, "", ID_LIST, RESPONSE_GET_LANEAREA_VARIABLE);
+}
+
+int TraCICommandInterface::LaneAreaDetector::getLastStepVehicleNumber() {
+    return traci->genericGetInt(CMD_GET_LANEAREA_VARIABLE, laneAreaDetectorId, LAST_STEP_VEHICLE_NUMBER, RESPONSE_GET_LANEAREA_VARIABLE);
+}
+	
 std::list<std::string> TraCICommandInterface::getJunctionIds() {
 	return genericGetStringList(CMD_GET_JUNCTION_VARIABLE, "", ID_LIST, RESPONSE_GET_JUNCTION_VARIABLE);
 }

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -115,6 +115,7 @@ class TraCICommandInterface
 
 				void setProgram(std::string program);
 				void setPhaseIndex(int32_t index);
+				int getPhaseIndex();
 
 			protected:
 				TraCICommandInterface* traci;
@@ -125,6 +126,25 @@ class TraCICommandInterface
 			return Trafficlight(this, trafficLightId);
 		}
 
+		// LaneAreaDetector methods
+		std::list<std::string> getLaneAreaDetectorIds();
+        	class LaneAreaDetector {
+	            	public:
+	    	            	LaneAreaDetector(TraCICommandInterface* traci, std::string laneAreaDetectorId) : traci(traci), laneAreaDetectorId(laneAreaDetectorId) {
+	                    connection = &traci->connection;
+	      	          	}
+
+        	        	int getLastStepVehicleNumber();
+
+            		protected:
+                		TraCICommandInterface* traci;
+                		TraCIConnection* connection;
+                		std::string laneAreaDetectorId;
+        	};
+        	LaneAreaDetector laneAreaDetector(std::string laneAreaDetectorId) {
+            		return LaneAreaDetector(this, laneAreaDetectorId);
+        	}
+	
 		// Polygon methods
 		std::list<std::string> getPolygonIds();
 		void addPolygon(std::string polyId, std::string polyType, const TraCIColor& color, bool filled, int32_t layer, const std::list<Coord>& points);

--- a/src/veins/modules/mobility/traci/TraCIConstants.h
+++ b/src/veins/modules/mobility/traci/TraCIConstants.h
@@ -75,7 +75,7 @@
 // response: subscribe induction loop (e1) variable
 #define RESPONSE_SUBSCRIBE_INDUCTIONLOOP_VARIABLE 0xe0
 
-
+/*
 // command: subscribe areal detector (e2) context
 #define CMD_SUBSCRIBE_AREAL_DETECTOR_CONTEXT 0x8D
 // response: subscribe areal detector (e2) context
@@ -88,7 +88,20 @@
 #define CMD_SUBSCRIBE_AREAL_DETECTOR_VARIABLE 0x8F
 // response: subscribe areal detector (e2) variable
 #define RESPONSE_SUBSCRIBE_AREAL_DETECTOR_VARIABLE 0x9F
+*/
 
+// command: subscribe areal detector (e2) context
+#define CMD_SUBSCRIBE_LANEAREA_CONTEXT 0x8d
+// response: subscribe areal detector (e2) context
+#define RESPONSE_SUBSCRIBE_LANEAREA_CONTEXT 0x9d
+// command: get areal detector (e2) variable
+#define CMD_GET_LANEAREA_VARIABLE 0xad
+// response: get areal detector (e2) variable
+#define RESPONSE_GET_LANEAREA_VARIABLE 0xbd
+// command: subscribe areal detector (e2) variable
+#define CMD_SUBSCRIBE_LANEAREA_VARIABLE 0xdd
+// response: subscribe areal detector (e2) variable
+#define RESPONSE_SUBSCRIBE_LANEAREA_VARIABLE 0xed
 
 // command: subscribe areal detector (e3) context
 #define CMD_SUBSCRIBE_MULTI_ENTRY_EXIT_DETECTOR_CONTEXT 0x81


### PR DESCRIPTION
Updates in "veins/src/veins/modules/mobility/traci" folder:

	- "TraCICommandInterface.h"
		- line 118: Added "getPhaseIndex" method, necessary to know the actual phase of the traffic light program, in order to decide the one to set up in the RSU logic
		- lines 129-146: Added "LaneAreaDetector" nested class, necessary to allow RSU unit requiring to SUMO's LaneAreaDetectors traffic information, in particular:
			- line 130: "getLaneAreaDetectorIds" method, necessary to know Ids of LaneAreaDetectors, in order to require informations to them and to classify their traffic as horizontal or vertical
			- line 137: "getLastStepVehicleNumber" method, necessary to know the traffic measured from this LaneAreaDetector, in order to feed the RSU logic

	- "TraCICommandInterface.cc"
		- lines 215-217: Implementation of the "getPhaseIndex" method, respecting the state of the art way of requiring information to SUMO
		- lines 321-327: Implementation of "getLaneAreaDetectorIds" and "getLastStepVehicleNumber" methods, respecting the state of the art way of requiring information to SUMO

	- "TraCIConstants.h"
		- lines 78-91: Commented areal detector (e2) constants because they are wrong or incompatible with my version of SUMO (0.29.0)
		- lines 93-104: Added areal detector (e2) constants true version or anyway compatible with my version of SUMO (0.29.0)