### PR TITLE
clean up nullptr-dereference compiler warning

### DIFF
--- a/src/veins/base/phyLayer/MappingUtils.h
+++ b/src/veins/base/phyLayer/MappingUtils.h
@@ -471,7 +471,7 @@ public:
 	/**
 	 * @brief This method isn't supported by an interpolated mapping.
 	 */
-	virtual const Argument& getNextPosition() const { assert(false); return *((Argument *)NULL); }
+	virtual const Argument& getNextPosition() const { throw std::logic_error("Not implemented!"); }
 };
 
 /**


### PR DESCRIPTION
remove badly written trap left over from mixim.
replace with meaningful exception.

this should clean up the compilation process a lot.