### PR TITLE
Features/configure python3

### DIFF
--- a/configure
+++ b/configure
@@ -11,6 +11,9 @@ from logging import info, warning, error
 from optparse import OptionParser
 
 
+if sys.version_info[0] == 3:
+    warning("Warning: running configure with python3 might result in subtle errors.")
+
 # Option handling
 parser = OptionParser()
 parser.add_option("--with-inet", dest="inet", help='Option discontinued in favor of a subproject in subprojects/veins_inet/')

--- a/configure
+++ b/configure
@@ -7,7 +7,7 @@ Creates Makefile(s) for building Veins.
 import os
 import sys
 import subprocess
-from logging import warning, error
+from logging import info, warning, error
 from optparse import OptionParser
 
 
@@ -43,4 +43,4 @@ f.close()
 
 subprocess.check_call(['env', 'opp_makemake'] + makemake_flags, cwd='src')
 
-print 'Configure done. You can now run "make".'
+info('Configure done. You can now run "make".')

--- a/subprojects/veins_catch/configure
+++ b/subprojects/veins_catch/configure
@@ -11,6 +11,9 @@ from logging import info, warning, error
 from optparse import OptionParser
 
 
+if sys.version_info[0] == 3:
+    warning("Warning: running configure with python3 might result in subtle errors.")
+
 # Option handling
 parser = OptionParser()
 parser.add_option("--with-veins", dest="veins", help="link Veins_INET with a version of Veins installed in PATH [default: do not link with Veins]", metavar="PATH", default="../..")

--- a/subprojects/veins_catch/configure
+++ b/subprojects/veins_catch/configure
@@ -7,7 +7,7 @@ Creates Makefile(s) for building veins_catch.
 import os
 import sys
 import subprocess
-from logging import warning, error
+from logging import info, warning, error
 from optparse import OptionParser
 
 
@@ -46,4 +46,4 @@ if not os.path.isdir('out'):
 
 subprocess.check_call(['env', 'opp_makemake'] + makemake_flags, cwd='src')
 
-print 'Configure done. You can now run "make".'
+info('Configure done. You can now run "make".')

--- a/subprojects/veins_inet/configure
+++ b/subprojects/veins_inet/configure
@@ -7,7 +7,7 @@ Creates Makefile(s) for building Veins_INET.
 import os
 import sys
 import subprocess
-from logging import warning, error
+from logging import info, warning, error
 from optparse import OptionParser
 
 
@@ -85,4 +85,4 @@ f.close()
 
 subprocess.check_call(['env', 'opp_makemake'] + makemake_flags, cwd='src')
 
-print 'Configure done. You can now run "make".'
+info('Configure done. You can now run "make".')

--- a/subprojects/veins_inet/configure
+++ b/subprojects/veins_inet/configure
@@ -11,6 +11,9 @@ from logging import info, warning, error
 from optparse import OptionParser
 
 
+if sys.version_info[0] == 3:
+    warning("Warning: running configure with python3 might result in subtle errors.")
+
 # Option handling
 parser = OptionParser()
 parser.add_option("--with-veins", dest="veins", help="link Veins_INET with a version of Veins installed in PATH [default: do not link with Veins]", metavar="PATH", default="../..")


### PR DESCRIPTION
Improve python3 compatibility in the configure scripts by using logging facilities instead of the print statement. This also improves consistency with existing code as other messages are also using the logging module.
Since python3 is not officially supported, a explicit warning has been added as this patchset will remove the obvious print statement error message when running configure with python3.