### PR TITLE
Add traci-initialized signal

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -38,6 +38,8 @@ using Veins::TraCICoord;
 
 Define_Module(Veins::TraCIScenarioManager);
 
+const std::string TraCIScenarioManager::TRACI_INITIALIZED_SIGNAL_NAME = "traciInitialized";
+
 TraCIScenarioManager::TraCIScenarioManager() :
 		myAddVehicleTimer(0),
 		mobRng(0),
@@ -45,7 +47,8 @@ TraCIScenarioManager::TraCIScenarioManager() :
 		connectAndStartTrigger(0),
 		executeOneTimestepTrigger(0),
 		world(0),
-		cc(0)
+		cc(0),
+		traciInitializedSignal(registerSignal(TRACI_INITIALIZED_SIGNAL_NAME.c_str()))
 {
 }
 
@@ -387,6 +390,8 @@ void TraCIScenarioManager::init_traci() {
 			}
 		}
 	}
+
+	emit(traciInitializedSignal, true);
 }
 
 void TraCIScenarioManager::finish() {

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -81,6 +81,8 @@ class TraCIScenarioManager : public cSimpleModule
 			VEH_SIGNAL_EMERGENCY_YELLOW = 8192
 		};
 
+		static const std::string TRACI_INITIALIZED_SIGNAL_NAME;
+
 		TraCIScenarioManager();
 		~TraCIScenarioManager();
 		virtual int numInitStages() const { return std::max(cSimpleModule::numInitStages(), 2); }
@@ -195,6 +197,8 @@ class TraCIScenarioManager : public cSimpleModule
 		 */
 		TypeMapping parseMappings(std::string parameter, std::string parameterName, bool allowEmpty = false);
 
+	private:
+		const omnetpp::simsignal_t traciInitializedSignal;
 };
 }
 

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.ned
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.ned
@@ -37,6 +37,7 @@ simple TraCIScenarioManagerForker
     parameters:
         @display("i=block/network2");
         @class(Veins::TraCIScenarioManagerForker);
+        @signal[traciInitialized](type=bool);
         bool debug = default(false);  // emit debug messages?
         double connectAt @unit("s") = default(0s);  // when to connect to TraCI server (must be the initial timestep of the server)
         double firstStepAt @unit("s") = default(-1s);  // when to start synchronizing with the TraCI server (-1: immediately after connecting)

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerLaunchd.ned
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerLaunchd.ned
@@ -41,6 +41,7 @@ simple TraCIScenarioManagerLaunchd
     parameters:
         @display("i=block/network2");
         @class(Veins::TraCIScenarioManagerLaunchd);
+        @signal[traciInitialized](type=bool);
         bool debug = default(false);  // emit debug messages?
         double connectAt @unit("s") = default(0s);  // when to connect to TraCI server (must be the initial timestep of the server)
         double firstStepAt @unit("s") = default(-1s);  // when to start synchronizing with the TraCI server (-1: immediately after connecting)


### PR DESCRIPTION
This signal enables other modules to be notified once the TraCIScenarioManager is initialzied. Previously the usual approach was to poll until `isConnected` returns true.