### PR TITLE
Add a SimpleTimerModule

### DIFF
--- a/src/veins/modules/utility/SimpleTimerModule.cc
+++ b/src/veins/modules/utility/SimpleTimerModule.cc
@@ -1,0 +1,69 @@
+#include "veins/modules/utility/SimpleTimerModule.h"
+
+using omnetpp::cMessage;
+using omnetpp::simtime_t;
+using omnetpp::simTime;
+using Veins::SimpleTimerModule;
+
+SimpleTimerModule::~SimpleTimerModule() {
+	for (const auto &timer : timers_) {
+		cancelAndDelete(timer.first);
+	}
+}
+
+void SimpleTimerModule::handleMessage(cMessage *message) {
+	auto *timer_message = dynamic_cast<SimpleTimerModule::TimerMessage*>(message);
+	if (!message->isSelfMessage() || !timer_message) {
+		EV_DEBUG << "Received non-timer-message or message from different module";
+		return;
+	}
+
+	auto timer = timers_.find(timer_message);
+	ASSERT(timer != timers_.end() && timer->second.validOccurence(simTime()));
+
+	timer->second.callback();
+
+	const auto next_event = simTime() + timer->second.period;
+	if (timer->second.validOccurence(next_event)) {
+		scheduleAt(next_event, timer->first);
+	} else {
+		cancelTimer(timer);
+	}
+}
+
+const SimpleTimerModule::Timer SimpleTimerModule::addOneshotTimer(const std::string &name, const std::function<void()> callback, const omnetpp::simtime_t time, const TimeInterpretation time_interpretation) {
+	return addRepeatingTimer(name, callback, 1, 1, time, time_interpretation);
+}
+
+const SimpleTimerModule::Timer SimpleTimerModule::addRepeatingTimer(const std::string &name, const std::function<void()> callback, const omnetpp::simtime_t period, const unsigned count, omnetpp::simtime_t start, const TimeInterpretation time_interpretation) {
+	ASSERT(count > 0);
+	if (start < 0) {
+		start = simTime() + period;
+	} else if (time_interpretation == TimeInterpretation::RELATIVE_TIME) {
+		start += simTime();
+	}
+	const auto end = start + (count - 1) * period;
+	return addRepeatingTimer(name, callback, period, start, end, TimeInterpretation::ABSOLUTE_TIME);
+}
+
+const SimpleTimerModule::Timer SimpleTimerModule::addRepeatingTimer(const std::string &name, const std::function<void()> callback, const omnetpp::simtime_t period, omnetpp::simtime_t start, omnetpp::simtime_t end, const TimeInterpretation time_interpretation) {
+	if (start < 0) {
+		start = simTime() + period;
+	} else if (time_interpretation == TimeInterpretation::RELATIVE_TIME) {
+		start += simTime();
+	}
+	if (end >= 0 && time_interpretation == TimeInterpretation::RELATIVE_TIME) {
+		end += simTime();
+	}
+
+	auto ret = timers_.insert({new SimpleTimerModule::TimerMessage(name), {start, end, period, callback}});
+	ASSERT(ret.second);
+	scheduleAt(start, ret.first->first);
+
+	return ret.first;
+}
+
+void SimpleTimerModule::cancelTimer(Timer timer) {
+	cancelEvent(timer->first);
+	timers_.erase(timer);
+}

--- a/src/veins/modules/utility/SimpleTimerModule.cc
+++ b/src/veins/modules/utility/SimpleTimerModule.cc
@@ -1,3 +1,22 @@
+//
+// Copyright (C) 2018-2018 Max Schettler <max.schettler@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
 #include "veins/modules/utility/SimpleTimerModule.h"
 
 using omnetpp::cMessage;

--- a/src/veins/modules/utility/SimpleTimerModule.h
+++ b/src/veins/modules/utility/SimpleTimerModule.h
@@ -23,7 +23,9 @@ class SimpleTimerModule : public omnetpp::cSimpleModule
 		virtual ~SimpleTimerModule() override;
 
 		/**
-		 * Handle messages arriving at this class. Wil
+		 * Handle messages arriving at this class.
+		 * 
+		 * Timers be handled by calling their callbacks and enqueuing their next event, if applicable.
 		 */
 		virtual void handleMessage(omnetpp::cMessage *message) override;
 
@@ -77,7 +79,7 @@ class SimpleTimerModule : public omnetpp::cSimpleModule
 		 * @param name The Timer's name. Used for its message.
 		 * @param callback Function which is called when the Timer triggers.
 		 * @param time Time at which the Timer triggers.
-		 * @param  time_interpretation Flag to indicate the semantics of the given time, see TimeScope.
+		 * @param time_interpretation Flag to indicate the semantics of the given time, see TimeScope.
 		 */
 		const Timer addOneshotTimer(const std::string &name, std::function<void()> callback, omnetpp::simtime_t time, TimeInterpretation time_interpretation=TimeInterpretation::RELATIVE_TIME);
 
@@ -113,10 +115,7 @@ class SimpleTimerModule : public omnetpp::cSimpleModule
 		void cancelTimer(Timer timer);
 
 	private:
-		/**
-		 * A list of all Timers which are currently active.
-		 */
-		TimerList timers_;
+		TimerList timers_; //! A list of all Timers which are currently active.
 };
 
 } // namespace Veins

--- a/src/veins/modules/utility/SimpleTimerModule.h
+++ b/src/veins/modules/utility/SimpleTimerModule.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <utility>
+
+#include <omnetpp.h>
+
+namespace Veins {
+
+/**
+ * A module that supports a clean interface for scheduling timers.
+ *
+ * @note This class overrides cSimpleModule::handleMessage such that you can not use cSimpleModule::activity if you subclass SimpleTimerModule.
+ */
+class SimpleTimerModule : public omnetpp::cSimpleModule
+{
+	public:
+		/**
+		 * Deletes this module.
+		 */
+		virtual ~SimpleTimerModule() override;
+
+		/**
+		 * Handle messages arriving at this class. Wil
+		 */
+		virtual void handleMessage(omnetpp::cMessage *message) override;
+
+	protected:
+		/**
+		 * A message which is used for triggering Timers.
+		 *
+		 * Its implementation is empty as it is only used to differentiate from other messages.
+		 */
+		struct TimerMessage : public omnetpp::cMessage {
+			TimerMessage(const std::string &name) : omnetpp::cMessage(name.c_str()) {}
+		};
+
+		/**
+		 * A class which specifies a Timer.
+		 *
+		 * This includes timing information as well as its callback.
+		 */
+		struct TimerSpec {
+			/**
+			 * Test whether the given time is a valid occurence.
+			 */
+			bool validOccurence(const omnetpp::simtime_t &time) const {
+				return start <= time && (end < 0 || end >= time);
+			}
+
+			omnetpp::simtime_t start; //! Time of the Timer's first occurence.
+			omnetpp::simtime_t end; //! Last possible time a Timer will trigger. Negative values encode never-ending Timers.
+			omnetpp::simtime_t period; //! Time between events.
+			std::function<void()> callback; //! The function to be called when the Timer is triggered.
+		};
+
+		typedef std::map<TimerMessage*, const TimerSpec> TimerList;
+		typedef TimerList::iterator Timer;
+
+		/**
+		 * Possible interpretations of a time value.
+		 */
+		enum class TimeInterpretation {
+			RELATIVE_TIME, //! Time will be interpreted relative to the current one.
+			ABSOLUTE_TIME //! Time describes a fixed point in time, independent of the current clock.
+		};
+
+		/**
+		 * Creates a new one-shot Timer.
+		 *
+		 * The given callback will be executed exactly once.
+		 * By default, the time is relative to the current time, i.e. a call with time=7 will be triggered in seven simulation seconds.
+		 * When passing time_scope=ABSOLUTE_TIME, the given time is interpreted as an absolute value and a call with time=7 will create a timer which triggers the given callback when simTime() equals seven seconds.
+		 *
+		 * @param name The Timer's name. Used for its message.
+		 * @param callback Function which is called when the Timer triggers.
+		 * @param time Time at which the Timer triggers.
+		 * @param  time_interpretation Flag to indicate the semantics of the given time, see TimeScope.
+		 */
+		const Timer addOneshotTimer(const std::string &name, std::function<void()> callback, omnetpp::simtime_t time, TimeInterpretation time_interpretation=TimeInterpretation::RELATIVE_TIME);
+
+		/**
+		 * Creates a Timer which will be triggered n-times.
+		 *
+		 * @param name The Timer's name. Used for its message.
+		 * @param callback Function which is called when the Timer triggers.
+		 * @param period Interval between two Timer occurences.
+		 * @param count Number of times the Timer will trigger.
+		 * @param start Time at which the Timer triggers first. Negative values will set start to the current simulation time plus one period.
+		 * @param time_interpretation Flag to indicate the semantics of the given time, see TimeScope.
+		 */
+		const Timer addRepeatingTimer(const std::string &name, std::function<void()> callback, omnetpp::simtime_t period, unsigned count, omnetpp::simtime_t start=-1, TimeInterpretation time_interpretation=TimeInterpretation::RELATIVE_TIME);
+
+		/**
+		 * Creates a Timer which will be triggered repeatedly in a specified interval.
+		 *
+		 * @param name The Timer's name. Used for its message.
+		 * @param callback Function which is called when the Timer triggers.
+		 * @param period Interval between two Timer occurences.
+		 * @param start Time at which the Timer triggers first. Negative values will set start to the current simulation time plus one period.
+		 * @param end Time at which the Timer triggers latest. Negative values indicate open-ended Timers.
+		 * @param time_interpretation Flag to indicate the semantics of the given time, see TimeScope.
+		 */
+		const Timer addRepeatingTimer(const std::string &name, std::function<void()> callback, omnetpp::simtime_t period, omnetpp::simtime_t start=-1, omnetpp::simtime_t end=-1, TimeInterpretation time_interpretation=TimeInterpretation::RELATIVE_TIME);
+
+		/**
+		 * Cancels the Timer which is specified by the given TimerMessage and prevents any further executions.
+		 *
+		 * @param timer_message The Timer which will be canceled.
+		 */
+		void cancelTimer(Timer timer);
+
+	private:
+		/**
+		 * A list of all Timers which are currently active.
+		 */
+		TimerList timers_;
+};
+
+} // namespace Veins

--- a/src/veins/modules/utility/SimpleTimerModule.h
+++ b/src/veins/modules/utility/SimpleTimerModule.h
@@ -52,10 +52,10 @@ class SimpleTimerModule : public omnetpp::cSimpleModule
 				return start <= time && (end < 0 || end >= time);
 			}
 
-			omnetpp::simtime_t start; //! Time of the Timer's first occurence.
-			omnetpp::simtime_t end; //! Last possible time a Timer will trigger. Negative values encode never-ending Timers.
-			omnetpp::simtime_t period; //! Time between events.
-			std::function<void()> callback; //! The function to be called when the Timer is triggered.
+			omnetpp::simtime_t start; ///< Time of the Timer's first occurence.
+			omnetpp::simtime_t end; ///< Last possible time a Timer will trigger. Negative values encode never-ending Timers.
+			omnetpp::simtime_t period; ///< Time between events.
+			std::function<void()> callback; ///< The function to be called when the Timer is triggered.
 		};
 
 		typedef std::map<TimerMessage*, const TimerSpec> TimerList;
@@ -65,8 +65,8 @@ class SimpleTimerModule : public omnetpp::cSimpleModule
 		 * Possible interpretations of a time value.
 		 */
 		enum class TimeInterpretation {
-			RELATIVE_TIME, //! Time will be interpreted relative to the current one.
-			ABSOLUTE_TIME //! Time describes a fixed point in time, independent of the current clock.
+			RELATIVE_TIME, ///< Time will be interpreted relative to the current one.
+			ABSOLUTE_TIME ///< Time describes a fixed point in time, independent of the current clock.
 		};
 
 		/**
@@ -115,7 +115,7 @@ class SimpleTimerModule : public omnetpp::cSimpleModule
 		void cancelTimer(Timer timer);
 
 	private:
-		TimerList timers_; //! A list of all Timers which are currently active.
+		TimerList timers_; ///< A list of all Timers which are currently active.
 };
 
 } // namespace Veins

--- a/src/veins/modules/utility/SimpleTimerModule.h
+++ b/src/veins/modules/utility/SimpleTimerModule.h
@@ -1,3 +1,22 @@
+//
+// Copyright (C) 2018-2018 Max Schettler <max.schettler@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
 #pragma once
 
 #include <functional>


### PR DESCRIPTION
The added module can be used as a base class instead of omnetpp::cSimpleModule to use timers.
There are three types of timers available:
- oneshot: Executed only once, at the specified time.
- repeating, by count: Repeated n-times. Each occurence is followed by an interval, the timers period.
- Repeating, interval based: A timer which repeats based on time boundaries. The start and end time can be omitted, to support open-ended timers.

The times which are passed can be given in relative (to the current simulation time) and absolute time. All timers can be cancelled at any time. Upon triggering, the timers execute a std::function based callback. Therefore, subclasses don't necessarily need to override cSimpleModule::handleMessage anymore if they to not receive any proper, i.e. networking messages. Also, one can call lambdas or pass additional parameters to the functions.

I tested this code by adapting the TraCIScenarioManager to it, this code is available [here](https://github.com/mightyCelu/veins/tree/tests/timer-module).

The downside to my code is, that the new module needs to be included in the class hierarchy and that subclasses can break parents by not calling their handleMessage. However, using it will simplify existing and new code a lot and allow for more readable and expressive code.