### PR TITLE
Feature/scenario manager cleanup

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -42,7 +42,6 @@ Define_Module(Veins::TraCIScenarioManager);
 const std::string TraCIScenarioManager::TRACI_INITIALIZED_SIGNAL_NAME = "traciInitialized";
 
 TraCIScenarioManager::TraCIScenarioManager() :
-		myAddVehicleTimer(0),
 		mobRng(0),
 		connection(0),
 		connectAndStartTrigger(0),
@@ -56,7 +55,6 @@ TraCIScenarioManager::TraCIScenarioManager() :
 TraCIScenarioManager::~TraCIScenarioManager() {
 	cancelAndDelete(connectAndStartTrigger);
 	cancelAndDelete(executeOneTimestepTrigger);
-	cancelAndDelete(myAddVehicleTimer);
 	delete commandIfc;
 	delete connection;
 }
@@ -265,8 +263,6 @@ void TraCIScenarioManager::initialize(int stage) {
 	vehicleRngIndex = par("vehicleRngIndex");
 	numVehicles = par("numVehicles").longValue();
 	mobRng = getRNG(vehicleRngIndex);
-
-	myAddVehicleTimer = new cMessage("myAddVehicleTimer");
 
 	annotations = AnnotationManagerAccess().getIfExists();
 

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -656,7 +656,7 @@ void TraCIScenarioManager::executeOneTimestep() {
 
 	uint32_t targetTime = simTime().inUnit(SIMTIME_MS);
 
-	if (targetTime > round(connectAt.dbl() * 1000)) {
+	if (isConnected()) {
 		insertVehicles();
 		TraCIBuffer buf = connection->query(CMD_SIMSTEP2, TraCIBuffer() << targetTime);
 

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -650,15 +650,11 @@ bool TraCIScenarioManager::isInRegionOfInterest(const TraCICoord& position, std:
 	return false;
 }
 
-uint32_t TraCIScenarioManager::getCurrentTimeMs() {
-	return static_cast<uint32_t>(round(simTime().dbl() * 1000));
-}
-
 void TraCIScenarioManager::executeOneTimestep() {
 
 	MYDEBUG << "Triggering TraCI server simulation advance to t=" << simTime() <<endl;
 
-	uint32_t targetTime = getCurrentTimeMs();
+	uint32_t targetTime = simTime().inUnit(SIMTIME_MS);
 
 	if (targetTime > round(connectAt.dbl() * 1000)) {
 		insertVehicles();
@@ -956,7 +952,7 @@ void TraCIScenarioManager::processSimSubscription(std::string objectId, TraCIBuf
 			ASSERT(varType == TYPE_INTEGER);
 			uint32_t serverTimestep; buf >> serverTimestep;
 			MYDEBUG << "TraCI reports current time step as " << serverTimestep << "ms." << endl;
-			uint32_t omnetTimestep = getCurrentTimeMs();
+			uint32_t omnetTimestep = simTime().inUnit(SIMTIME_MS);
 			ASSERT(omnetTimestep == serverTimestep);
 
 		} else {

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -122,7 +122,6 @@ class TraCIScenarioManager : public cSimpleModule
 		std::vector<std::string> trafficLightModuleIds; /**< list of traffic light module ids that is subscribed to (whitelist) */
 
 		uint32_t vehicleNameCounter;
-		cMessage* myAddVehicleTimer;
 		std::vector<std::string> vehicleTypeIds;
 		std::map<int, std::queue<std::string> > vehicleInsertQueue;
 		std::set<std::string> queuedVehicles;

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -158,8 +158,6 @@ class TraCIScenarioManager : public cSimpleModule
 		BaseWorldUtility* world;
 		BaseConnectionManager* cc;
 
-		uint32_t getCurrentTimeMs(); /**< get current simulation time (in ms) */
-
 		void executeOneTimestep(); /**< read and execute all commands for the next timestep */
 
 		virtual void init_traci();


### PR DESCRIPTION
This PR includes a few commits which do some cleanup of the TraCIScenarioManager.
This includes:
- remove getCurrentTimeMs as the Omnet++ API provides this functionality directly
- turn manual check into a call to the manager's public interface
- use the proper debugg-macro
- remove unused timer