### PR TITLE
Extract coord / angle conversion into helper class

### DIFF
--- a/src/veins/modules/mobility/traci/NetworkBoundary.cc
+++ b/src/veins/modules/mobility/traci/NetworkBoundary.cc
@@ -1,0 +1,109 @@
+//
+// Copyright (C) 2018 Dominik S. Buse <buse@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#include "veins/modules/mobility/traci/NetworkBoundary.h"
+
+namespace Veins {
+
+using OmnetCoord = NetworkBoundary::OmnetCoord;
+using OmnetCoordList = NetworkBoundary::OmnetCoordList;
+using TraCICoordList = NetworkBoundary::TraCICoordList;
+using Angle = NetworkBoundary::Angle;
+
+NetworkBoundary::NetworkBoundary(TraCICoord topleft, TraCICoord bottomright, float margin)
+    : dimensions( {bottomright.x - topleft.x, bottomright.y - topleft.y} )
+    , topleft(topleft)
+    , bottomright(bottomright)
+    , margin(margin)
+{}
+
+TraCICoord NetworkBoundary::omnet2traci(const OmnetCoord& coord) const
+{
+    return {
+        coord.x + topleft.x - margin,
+        dimensions.y - (coord.y - topleft.y) + margin
+    };
+}
+
+TraCICoordList NetworkBoundary::omnet2traci(const OmnetCoordList& coords) const
+{
+    TraCICoordList result;
+    for(auto&& coord : coords) {
+        result.push_back(omnet2traci(coord));
+    }
+    return result;
+}
+
+Angle NetworkBoundary::omnet2traciAngle(Angle angle) const
+{
+    // convert to degrees
+    angle = angle * 180 / M_PI;
+
+    // rotate angle so 0 is south (in OMNeT++'s angle interpretation 0 is east, 90 is north)
+    angle = 90 - angle;
+
+    // normalize angle to -180 <= angle < 180
+    while (angle < -180) {
+        angle += 360;
+    }
+    while (angle >= 180) {
+        angle -= 360;
+    }
+
+    return angle;
+}
+
+OmnetCoord NetworkBoundary::traci2omnet(const TraCICoord& coord) const
+{
+    return {
+        coord.x - topleft.x + margin,
+        dimensions.y - (coord.y - topleft.y) + margin
+    };
+}
+
+OmnetCoordList NetworkBoundary::traci2omnet(const TraCICoordList& coords) const
+{
+    OmnetCoordList result;
+    for(auto&& coord : coords) {
+        result.push_back(traci2omnet(coord));
+    }
+    return result;
+}
+
+Angle NetworkBoundary::traci2omnetAngle(Angle angle) const
+{
+    // rotate angle so 0 is east (in TraCI's angle interpretation 0 is north, 90 is east)
+    angle = 90 - angle;
+
+    // convert to rad
+    angle = angle * M_PI / 180.0;
+
+    // normalize angle to -M_PI <= angle < M_PI
+    while (angle < -M_PI) {
+        angle += 2 * M_PI;
+    }
+    while (angle >= M_PI) {
+        angle -= 2 * M_PI;
+    }
+
+    return angle;
+}
+
+} // end namespace Veins

--- a/src/veins/modules/mobility/traci/NetworkBoundary.h
+++ b/src/veins/modules/mobility/traci/NetworkBoundary.h
@@ -1,0 +1,59 @@
+//
+// Copyright (C) 2018 Dominik S. Buse <buse@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#ifndef VEINS_MOBILITY_TRACI_NETWORKBOUNDARY_H_
+#define VEINS_MOBILITY_TRACI_NETWORKBOUNDARY_H_
+
+#include "veins/modules/mobility/traci/TraCICoord.h"
+#include "veins/base/utils/Coord.h"
+
+#include <list>
+
+namespace Veins {
+
+/*
+ * Helper class for converting SUMO coordinates to OMNeT++ Coordinates for a given network.
+ */
+class NetworkBoundary
+{
+public:
+    using OmnetCoord = Coord;
+    using OmnetCoordList = std::list<OmnetCoord>;
+    using TraCICoordList = std::list<TraCICoord>;
+    using Angle = double;
+
+    NetworkBoundary(TraCICoord topleft, TraCICoord bottomright, float margin);
+    TraCICoord omnet2traci(const OmnetCoord& coord) const;
+    TraCICoordList omnet2traci(const OmnetCoordList& coords) const;
+    Angle omnet2traciAngle(Angle angle) const;
+
+    OmnetCoord traci2omnet(const TraCICoord& coord) const;
+    OmnetCoordList traci2omnet(const TraCICoordList& coords) const;
+    Angle traci2omnetAngle(Angle angle) const;
+private:
+    TraCICoord dimensions;
+    TraCICoord topleft;
+    TraCICoord bottomright;
+    float margin;
+}; // end class NetworkCoordinateTranslator
+
+} // end namespace Veins
+
+#endif

--- a/src/veins/modules/mobility/traci/TraCIConnection.cc
+++ b/src/veins/modules/mobility/traci/TraCIConnection.cc
@@ -221,59 +221,37 @@ std::string makeTraCICommand(uint8_t commandId, const TraCIBuffer& buf) {
 }
 
 void TraCIConnection::setNetbounds(TraCICoord netbounds1, TraCICoord netbounds2, int margin) {
-	this->netbounds1 = netbounds1;
-	this->netbounds2 = netbounds2;
-	this->margin = margin;
+	netbound.reset(new NetworkBoundary(netbounds1, netbounds2, margin));
 }
 
 Coord TraCIConnection::traci2omnet(TraCICoord coord) const {
-	return Coord(coord.x - netbounds1.x + margin, (netbounds2.y - netbounds1.y) - (coord.y - netbounds1.y) + margin);
+	ASSERT(netbound.get());
+	return netbound->traci2omnet(coord);
 }
 
 std::list<Coord> TraCIConnection::traci2omnet(const std::list<TraCICoord>& list) const {
-	std::list<Coord> result;
-	std::transform(list.begin(), list.end(), std::back_inserter(result), traci2omnet_functor(*this));
-	return result;
+	ASSERT(netbound.get());
+	return netbound->traci2omnet(list);
 }
 
 TraCICoord TraCIConnection::omnet2traci(Coord coord) const {
-	return TraCICoord(coord.x + netbounds1.x - margin, (netbounds2.y - netbounds1.y) - (coord.y - netbounds1.y) + margin);
+	ASSERT(netbound.get());
+	return netbound->omnet2traci(coord);
 }
 
 std::list<TraCICoord> TraCIConnection::omnet2traci(const std::list<Coord>& list) const {
-	std::list<TraCICoord> result;
-	std::transform(list.begin(), list.end(), std::back_inserter(result), std::bind1st(std::mem_fun<TraCICoord, TraCIConnection, Coord>(&TraCIConnection::omnet2traci), this));
-	return result;
+	ASSERT(netbound.get());
+	return netbound->omnet2traci(list);
 }
 
 double TraCIConnection::traci2omnetAngle(double angle) const {
-
-	// rotate angle so 0 is east (in TraCI's angle interpretation 0 is north, 90 is east)
-	angle = 90 - angle;
-
-	// convert to rad
-	angle = angle * M_PI / 180.0;
-
-	// normalize angle to -M_PI <= angle < M_PI
-	while (angle < -M_PI) angle += 2 * M_PI;
-	while (angle >= M_PI) angle -= 2 * M_PI;
-
-	return angle;
+	ASSERT(netbound.get());
+	return netbound->traci2omnetAngle(angle);
 }
 
 double TraCIConnection::omnet2traciAngle(double angle) const {
-
-	// convert to degrees
-	angle = angle * 180 / M_PI;
-
-	// rotate angle so 0 is south (in OMNeT++'s angle interpretation 0 is east, 90 is north)
-	angle = 90 - angle;
-
-	// normalize angle to -180 <= angle < 180
-	while (angle < -180) angle += 360;
-	while (angle >= 180) angle -= 360;
-
-	return angle;
+	ASSERT(netbound.get());
+	return netbound->omnet2traciAngle(angle);
 }
 
 }

--- a/src/veins/modules/mobility/traci/TraCIConnection.h
+++ b/src/veins/modules/mobility/traci/TraCIConnection.h
@@ -2,6 +2,8 @@
 #define VEINS_MOBILITY_TRACI_TRACICONNECTION_H_
 
 #include <stdint.h>
+#include <memory>
+#include "veins/modules/mobility/traci/NetworkBoundary.h"
 #include "veins/modules/mobility/traci/TraCIBuffer.h"
 #include "veins/modules/mobility/traci/TraCICoord.h"
 #include "veins/base/utils/Coord.h"
@@ -61,10 +63,7 @@ class TraCIConnection
 		TraCIConnection(void*);
 
 		void* socketPtr;
-		TraCICoord netbounds1; /* network boundaries as reported by TraCI (x1, y1) */
-		TraCICoord netbounds2; /* network boundaries as reported by TraCI (x2, y2) */
-		int margin;
-
+		std::unique_ptr<NetworkBoundary> netbound;
 };
 
 /**

--- a/subprojects/veins_catch/src/traci/NetworkBoundary.cc
+++ b/subprojects/veins_catch/src/traci/NetworkBoundary.cc
@@ -1,0 +1,68 @@
+#include "catch/catch.hpp"
+#include "veins/modules/mobility/traci/NetworkBoundary.h"
+#include "veins/modules/mobility/traci/TraCICoord.h"
+
+using Veins::NetworkBoundary;
+using Veins::TraCICoord;
+using OmnetCoord = NetworkBoundary::OmnetCoord;
+using TraCICoordList = NetworkBoundary::TraCICoordList;
+using OmnetCoordList = NetworkBoundary::OmnetCoordList;
+
+SCENARIO( "NetworkBoundary gets build with network boundaries", "[netbound]") {
+    GIVEN( "A network size from (5, 10) to (105, 210) with margin 10" ) {
+        Veins::TraCICoord topleft(5, 10);
+        Veins::TraCICoord bottomright(105, 210);
+        float margin = 10;
+        THEN( "A NetworkCoordinateTranslator can be build from it" ) {
+            NetworkBoundary nb{topleft, bottomright, margin};
+            REQUIRE( &nb );
+        }
+    }
+}
+
+SCENARIO( "NetworkBoundary correctly translates for Erlangen boundaries", "[netbound]") {
+    auto orig_omnet = OmnetCoord(2414.90142, 1578.44161, 0.0);
+    auto orig_traci = TraCICoord(646854.991, 5493242.54);
+    OmnetCoordList orig_omnet_list = { orig_omnet };
+    TraCICoordList orig_traci_list = { orig_traci };
+    double orig_traci_angle = -114.542;
+    double orig_omnet_angle = -2.71324;
+
+    GIVEN( "The boundaries from the Erlangen scenario" ) {
+        NetworkBoundary nb{ {644465.09, 5491786.25}, {647071.55,5494795.98}, 25 };
+
+        // single coordinates
+        THEN( "omnet coords correctly translate to traci coords" ) {
+            auto new_traci = nb.omnet2traci(orig_omnet);
+            REQUIRE( new_traci.x == Approx(orig_traci.x) );
+            REQUIRE( new_traci.y == Approx(orig_traci.y) );
+        }
+        THEN( "traci coords correctly translate to omnet coords" ) {
+            auto new_omnet = nb.traci2omnet(orig_traci);
+            REQUIRE( new_omnet.x == Approx(orig_omnet.x) );
+            REQUIRE( new_omnet.y == Approx(orig_omnet.y) );
+        }
+
+        // lists of coordinates
+        THEN( "omnet coord lists correctly translate to traci coord lists" ) {
+            auto new_traci = nb.omnet2traci(orig_omnet_list);
+            REQUIRE( new_traci.front().x == Approx(orig_traci.x) );
+            REQUIRE( new_traci.front().y == Approx(orig_traci.y) );
+        }
+        THEN( "traci coord lists correctly translate to omnet coord lists" ) {
+            auto new_omnet = nb.traci2omnet(orig_traci_list);
+            REQUIRE( new_omnet.front().x == Approx(orig_omnet.x) );
+            REQUIRE( new_omnet.front().y == Approx(orig_omnet.y) );
+        }
+
+        // angles
+        THEN( "omnet angles correctly translate to traci angles" ) {
+            auto new_traci = nb.omnet2traciAngle(orig_omnet_angle);
+            REQUIRE( new_traci == Approx(orig_traci_angle) );
+        }
+        THEN( "traci angles correctly translate to omnet angles" ) {
+            auto new_omnet = nb.traci2omnetAngle(orig_traci_angle);
+            REQUIRE( new_omnet == Approx(orig_omnet_angle) );
+        }
+    }
+}


### PR DESCRIPTION
Conversion between TraCI and OMNeT++ representations are now handled by a new class, NetworkBoundary.
The interface through TraCIConnection is unchanged for now, the implementation is simply forwarded.
Comes with tests for catch2.

New attempt at #11 , which would no longer merge due to changes in the TraCI api.