### PR TITLE
Handle self-messages according to omnetpp manual

### DIFF
--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -399,6 +399,18 @@ void Mac1609_4::finish() {
 
 }
 
+Mac1609_4::~Mac1609_4() {
+	if (nextMacEvent) {
+		cancelAndDelete(nextMacEvent);
+		nextMacEvent = nullptr;
+	}
+
+	if (nextChannelSwitch) {
+		cancelAndDelete(nextChannelSwitch);
+		nextChannelSwitch= nullptr;
+	}
+};
+
 void Mac1609_4::attachSignal(Mac80211Pkt* mac, simtime_t startTime, double frequency, uint64_t datarate, double txPower_mW) {
 
 	simtime_t duration = getFrameDuration(mac->getBitLength());

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -383,15 +383,6 @@ void Mac1609_4::finish() {
 
 	myEDCA.clear();
 
-	if (nextMacEvent->isScheduled()) {
-		cancelAndDelete(nextMacEvent);
-	}
-	else {
-		delete nextMacEvent;
-	}
-	if (nextChannelSwitch && nextChannelSwitch->isScheduled())
-		cancelAndDelete(nextChannelSwitch);
-
 	//stats
 	recordScalar("ReceivedUnicastPackets",statsReceivedPackets);
 	recordScalar("ReceivedBroadcasts",statsReceivedBroadcasts);

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -124,17 +124,7 @@ class Mac1609_4 : public BaseMacLayer,
 
 	public:
 		Mac1609_4() : nextMacEvent(nullptr), nextChannelSwitch(nullptr) {}
-		~Mac1609_4() {
-			if (nextMacEvent) {
-				cancelAndDelete(nextMacEvent);
-				nextMacEvent = nullptr;
-			}
-
-			if (nextChannelSwitch) {
-				cancelAndDelete(nextChannelSwitch);
-				nextChannelSwitch= nullptr;
-			}
-		};
+		~Mac1609_4();
 
 		/**
 		 * @brief return true if alternate access is enabled

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -123,7 +123,18 @@ class Mac1609_4 : public BaseMacLayer,
 		};
 
 	public:
-		~Mac1609_4() { };
+		Mac1609_4() : nextMacEvent(nullptr), nextChannelSwitch(nullptr) {}
+		~Mac1609_4() {
+			if (nextMacEvent) {
+				cancelAndDelete(nextMacEvent);
+				nextMacEvent = nullptr;
+			}
+
+			if (nextChannelSwitch) {
+				cancelAndDelete(nextChannelSwitch);
+				nextChannelSwitch= nullptr;
+			}
+		};
 
 		/**
 		 * @brief return true if alternate access is enabled


### PR DESCRIPTION
This fixes the undisposed object after incorrect termination of the
simulation (thus finish is not called) and initializes pointers
correctly. Also the pointer variable is deleted (i.e. set to nullptr).

Excerpt from the [manual](https://omnetpp.org/doc/omnetpp/manual/#sec:simple-modules:initialize-and-finish)

> finish():
> 
> Record statistics. Do not delete anything or cancel timers -- all cleanup must be done in the destructor.
> 
> Destructor:
> 
> Delete everything which was allocated by new and is still held by the module class. With self-messages (timers), use the cancelAndDelete(msg) function! It is almost always wrong to just delete a self-message from the destructor, because it might be in the scheduled events list. The cancelAndDelete(msg) function checks for that first, and cancels the message before deletion if necessary.
> 
> OMNeT++ prints the list of unreleased objects at the end of the simulation. When a simulation model dumps "undisposed object ..." messages, this indicates that the corresponding module destructors should be fixed. As a temporary measure, these messages may be hidden by setting print-undisposed=false in the configuration. 