### PR TITLE
Feature/unicast integration

### DIFF
--- a/src/veins/base/phyLayer/MacToPhyInterface.h
+++ b/src/veins/base/phyLayer/MacToPhyInterface.h
@@ -33,9 +33,6 @@ public:
 		CHANNEL_SENSE_REQUEST,
 		/** @brief AirFrame kind */
 		AIR_FRAME,
-		/** @brief Stores the id on which classes extending BasePhy should
-		 * continue their own kinds.*/
-		LAST_BASE_PHY_KIND,
 		/** @brief PHY-RXSTART.indication. Used in ack procedure for unicast
 		 */
 		PHY_RX_START,
@@ -45,6 +42,9 @@ public:
 		/** @brief PHY-RXEND.indication and Rx failed
 		 */
 		PHY_RX_END_WITH_FAILURE,
+		/** @brief Stores the id on which classes extending BasePhy should
+		 * continue their own kinds.*/
+		LAST_BASE_PHY_KIND,
 	};
 
 public:

--- a/src/veins/base/phyLayer/MacToPhyInterface.h
+++ b/src/veins/base/phyLayer/MacToPhyInterface.h
@@ -36,6 +36,15 @@ public:
 		/** @brief Stores the id on which classes extending BasePhy should
 		 * continue their own kinds.*/
 		LAST_BASE_PHY_KIND,
+		/** @brief PHY-RXSTART.indication. Used in ack procedure for unicast
+		 */
+		PHY_RX_START,
+		/** @brief PHY-RXEND.indication and Rx was successful
+		 */
+		PHY_RX_END_WITH_SUCCESS,
+		/** @brief PHY-RXEND.indication and Rx failed
+		 */
+		PHY_RX_END_WITH_FAILURE,
 	};
 
 public:

--- a/src/veins/modules/application/ieee80211p/BaseWaveApplLayer.h
+++ b/src/veins/modules/application/ieee80211p/BaseWaveApplLayer.h
@@ -83,7 +83,7 @@ class BaseWaveApplLayer : public BaseApplLayer {
         virtual void handleSelfMsg(cMessage* msg);
 
         /** @brief sets all the necessary fields in the WSM, BSM, or WSA. */
-        virtual void populateWSM(WaveShortMessage*  wsm, int rcvId=0, int serial=0);
+        virtual void populateWSM(WaveShortMessage*  wsm, int rcvId=-1, int serial=0);
 
         /** @brief this function is called upon receiving a WaveShortMessage */
         virtual void onWSM(WaveShortMessage* wsm) { };

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -263,7 +263,7 @@ void Mac1609_4::handleSelfMsg(cMessage* msg) {
 				waitUntilAckRXorTimeout = true;
 				// PHY-RXSTART.indication should be received within ackWaitTime
 				// sifs + slot + rx_delay: see 802.11-2012 9.3.2.8 (32us + 13us + 49us = 94us)
-				simtime_t ackWaitTime = SimTime().setRaw(94000000UL);
+				simtime_t ackWaitTime(94, SIMTIME_US);
 				// update id in the retransmit timer
 				myEDCA[activeChannel]->myQueues[lastAC].ackTimeOut->setUniqueId(pktToSend->getUniqueId());
 				simtime_t timeOut = sendingDuration + ackWaitTime;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -148,6 +148,7 @@ void Mac1609_4::initialize(int stage) {
 		statsReceivedPackets = 0;
 		statsReceivedBroadcasts = 0;
 		statsSentPackets = 0;
+		statsSentAcks = 0;
 		statsTXRXLostPackets = 0;
 		statsSNIRLostPackets = 0;
 		statsDroppedPackets = 0;
@@ -445,6 +446,7 @@ void Mac1609_4::finish() {
 	recordScalar("ReceivedUnicastPackets",statsReceivedPackets);
 	recordScalar("ReceivedBroadcasts",statsReceivedBroadcasts);
 	recordScalar("SentPackets",statsSentPackets);
+	recordScalar("SentAcknowledgements",statsSentAcks);
 	recordScalar("SNIRLostPackets",statsSNIRLostPackets);
 	recordScalar("RXTXLostPackets",statsTXRXLostPackets);
 	recordScalar("TotalLostPackets",statsSNIRLostPackets+statsTXRXLostPackets);
@@ -481,7 +483,9 @@ void Mac1609_4::sendFrame(Mac80211Pkt* frame, simtime_t delay, double frequency,
 	lastMac.reset(frame->dup());
 	sendDelayed(frame, delay, lowerLayerOut);
 
-	if (!dynamic_cast<Mac80211Ack*>(frame)) {
+	if (dynamic_cast<Mac80211Ack*>(frame)) {
+		statsSentAcks += 1;
+	} else {
 		statsSentPackets += 1;
 	}
 }

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -102,7 +102,7 @@ void Mac1609_4::initialize(int stage) {
 
 		useSCH = par("useServiceChannel").boolValue();
 		if (useSCH) {
-			if (useACKs) throw cRuntimeError("Unicast model does not support channel switching yet :(");
+			if (useACKs) throw cRuntimeError("Unicast model does not support channel switching");
 			//set the initial service channel
 			switch (par("serviceChannel").longValue()) {
 				case 1: mySCH = Channels::SCH1; break;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -63,7 +63,6 @@ void Mac1609_4::initialize(int stage) {
 		dot11LongRetryLimit = par("dot11LongRetryLimit");
 		ackLength = par("ackLength");
 		useACKs = par("useAcks").boolValue();
-		simulateErrorsInACK = par("simulateErrorsInACK").boolValue();
 		ackErrorRate = par("ackErrorRate").doubleValue();
 		rxStartIndication = false;
 		ignoreChannelState = false;
@@ -600,9 +599,7 @@ void Mac1609_4::handleLowerMsg(cMessage* msg) {
 				}
 			} else {
 				if (useACKs) {
-					if (!simulateErrorsInACK || dblrand(1) > ackErrorRate) {
-						sendACK(wsm->getSenderAddress(), wsm->getUniqueId());
-					}
+					sendACK(wsm->getSenderAddress(), wsm->getUniqueId());
 				}
 				std::set<unsigned long>::iterator itr = handledUnicastToApp.find(wsm->getUniqueId());
 				if (itr != handledUnicastToApp.end()) {

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -586,16 +586,7 @@ void Mac1609_4::handleLowerMsg(cMessage* msg) {
 				// We received an ACK
 				sendWsmUp = false;
 				if (useAcks) {
-					if (rxStartIndication) {
-						// We were expecting an ack
-						phy11p->notifyMacAboutRxStart(false);
-						rxStartIndication = false;
-						handleAck(ack);
-					} else {
-						if (dest == myMacAddress) {
-							throw cRuntimeError("Not expecting ack, still received one!! Should never occur...");
-						}
-					}
+					handleAck(ack);
 				}
 			} else {
 				if (useAcks) {
@@ -1049,6 +1040,10 @@ void Mac1609_4::sendAck(int recpAddress, unsigned long uniqueNumber) {
 }
 
 void Mac1609_4::handleAck(WaveShortMessageACK* ack) {
+	ASSERT2(rxStartIndication, "Not expecting ack");
+	phy11p->notifyMacAboutRxStart(false);
+	rxStartIndication = false;
+
 	t_channel chan = type_CCH;
 	bool queueUnblocked = false;
 	for (std::map<t_access_category, EDCA::EDCAQueue>::iterator iter = myEDCA[chan]->myQueues.begin(); iter != myEDCA[chan]->myQueues.end(); iter++) {

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -209,7 +209,7 @@ void Mac1609_4::handleSelfMsg(cMessage* msg) {
 
 		//send the packet
 		Mac80211Pkt* mac = new Mac80211Pkt(pktToSend->getName(), pktToSend->getKind());
-		if (pktToSend->getIsUnicast()) {
+		if (pktToSend->getRecipientAddress() != -1) {
 			mac->setDestAddr(pktToSend->getRecipientAddress());
 		} else {
 			mac->setDestAddr(LAddress::L2BROADCAST());
@@ -259,7 +259,7 @@ void Mac1609_4::handleSelfMsg(cMessage* msg) {
 			sendDelayed(mac, RADIODELAY_11P, lowerLayerOut);
 
 			// schedule ack timeout for unicast packets
-			if (pktToSend->getIsUnicast() && useACKs) {
+			if (pktToSend->getRecipientAddress() != -1 && useACKs) {
 				waitUntilAckRXorTimeout = true;
 				// PHY-RXSTART.indication should be received within ackWaitTime
 				// sifs + slot + rx_delay: see 802.11-2012 9.3.2.8 (32us + 13us + 49us = 94us)
@@ -581,7 +581,7 @@ void Mac1609_4::handleLowerMsg(cMessage* msg) {
 	if (macPkt->getDestAddr() == myMacAddress) {
 
 		bool sendWsmUp = true;
-		if (wsm->getIsUnicast()) {
+		if (wsm->getRecipientAddress() != -1) {
 			WaveShortMessageACK* ack = dynamic_cast<WaveShortMessageACK*>(wsm);
 			if (ack) {
 				// We received an ACK
@@ -835,7 +835,7 @@ void Mac1609_4::EDCA::postTransmit(t_access_category ac, WaveShortMessage* wsm, 
 		// We sent an acknowledgment. Do nothing.
 		return;
 	}
-	bool holBlocking = wsm->getIsUnicast() && useAcks;
+	bool holBlocking = (wsm->getRecipientAddress() != -1) && useAcks;
 	if (holBlocking) {
 		//mac->waitUntilAckRXorTimeout = true; // set in handleselfmsg()
 		// Head of line blocking, wait until ack timeout
@@ -1017,7 +1017,6 @@ void Mac1609_4::sendACK(int recpAddress, unsigned long uniqueNumber) {
 	ack->setRecipientAddress(recpAddress);
 	ack->setUniqueId(uniqueNumber);
 	ack->setBitLength(ackLength);
-	ack->setIsUnicast(true);
 
 	// send the packet
 	Mac80211Pkt* mac = new Mac80211Pkt(ack->getName(), ack->getKind());

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -33,6 +33,8 @@
 #include "veins/base/utils/FindModule.h"
 #include "veins/modules/messages/Mac80211Pkt_m.h"
 #include "veins/modules/messages/WaveShortMessage_m.h"
+#include "veins/modules/messages/AckTimeOutMessage_m.h"
+#include "veins/modules/messages/WaveShortMessageACK_m.h"
 #include "veins/base/modules/BaseMacLayer.h"
 
 #include "veins/modules/utility/ConstsPhy.h"
@@ -45,6 +47,7 @@
  * @author Christoph Sommer : features and bug fixes
  * @author Michele Segata : features and bug fixes
  * @author Stefan Joerer : features and bug fixes
+ * @author Gurjashan Pannu: features (unicast model)
  * @author Christopher Saloman: initial version
  *
  * @ingroup macLayer
@@ -80,9 +83,16 @@ class Mac1609_4 : public BaseMacLayer,
 						int cwCur; //current contention window
 						int64_t currentBackoff; //current Backoff value for this queue
 						bool txOP;
+						int ssrc; // station short retry count
+						int slrc; // station long retry count
+						bool waitForAck; // true if the queue is waiting for an acknowledgment for unicast
+						unsigned long waitOnUnicastID; // unique id of unicast on which station is waiting
+						AckTimeOutMessage* ackTimeOut; // timer for retransmission on receiving no ACK
 
 						EDCAQueue() {	};
-						EDCAQueue(int aifsn,int cwMin, int cwMax, t_access_category ac):aifsn(aifsn),cwMin(cwMin),cwMax(cwMax),cwCur(cwMin),currentBackoff(0),txOP(false) {
+						EDCAQueue(int aifsn,int cwMin, int cwMax, t_access_category ac):aifsn(aifsn),cwMin(cwMin),cwMax(cwMax),cwCur(cwMin),currentBackoff(0),txOP(false),ssrc(0),slrc(0),waitForAck(false),waitOnUnicastID(-1) {
+							ackTimeOut = new AckTimeOutMessage("AckTimeOut");
+							ackTimeOut->setKind(ac);
 						};
 				};
 
@@ -98,7 +108,7 @@ class Mac1609_4 : public BaseMacLayer,
 				void backoff(t_access_category ac);
 				simtime_t startContent(simtime_t idleSince, bool guardActive);
 				void stopContent(bool allowBackoff, bool generateTxOp);
-				void postTransmit(t_access_category);
+				void postTransmit(t_access_category, WaveShortMessage* wsm, bool useAcks);
 				void revokeTxOPs();
 
 				void cleanUp();
@@ -207,6 +217,10 @@ class Mac1609_4 : public BaseMacLayer,
 
 		simtime_t getFrameDuration(int payloadLengthBits, enum PHY_MCS mcs = MCS_DEFAULT) const;
 
+		void sendACK(int recpAddress, unsigned long uniqueNumber);
+		void handleACK(WaveShortMessageACK* ack);
+		void handleAckTimeOut(AckTimeOutMessage* ackTimeOutMsg);
+		void handleRetransmit(t_access_category ac);
 	protected:
 		/** @brief Self message to indicate that the current channel shall be switched.*/
 		cMessage* nextChannelSwitch;
@@ -223,6 +237,9 @@ class Mac1609_4 : public BaseMacLayer,
 
 		/** @brief access category of last sent packet */
 		t_access_category lastAC;
+
+		/** @brief pointer to last sent packet */
+		WaveShortMessage* lastWSM;
 
 		/** @brief Stores the frequencies in Hz that are associated to the channel numbers.*/
 		std::map<int,double> frequency;
@@ -263,6 +280,25 @@ class Mac1609_4 : public BaseMacLayer,
 
 		/** @brief Id for debug messages */
 		std::string myId;
+
+		bool useACKs;
+		bool simulateErrorsInACK;
+		double ackErrorRate;
+		int dot11RTSThreshold;
+		int dot11ShortRetryLimit;
+		int dot11LongRetryLimit;
+		int ackLength;
+
+		// indicates rx start within the period of ACK timeout
+		bool rxStartIndication;
+
+		// An ack is sent after SIFS irrespective of the channel state
+		cMessage* stopIgnoreChannelStateMsg;
+		bool ignoreChannelState;
+
+		// Dont start contention immediately after finishing unicast TX. Wait until ack timeout/ ack Rx
+		bool waitUntilAckRXorTimeout;
+		std::set<unsigned long> handledUnicastToApp;
 
 		Mac80211pToPhy11pInterface* phy11p;
 

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -264,6 +264,7 @@ class Mac1609_4 : public BaseMacLayer,
 		long statsReceivedPackets;
 		long statsReceivedBroadcasts;
 		long statsSentPackets;
+		long statsSentAcks;
 		long statsTXRXLostPackets;
 		long statsSNIRLostPackets;
 		long statsDroppedPackets;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -24,6 +24,7 @@
 #include <assert.h>
 #include <omnetpp.h>
 #include <queue>
+#include <memory>
 #include <stdint.h>
 #include "veins/base/modules/BaseLayer.h"
 #include "veins/base/phyLayer/MacToPhyControlInfo.h"
@@ -218,6 +219,7 @@ class Mac1609_4 : public BaseMacLayer,
 		simtime_t getFrameDuration(int payloadLengthBits, enum PHY_MCS mcs = MCS_DEFAULT) const;
 
 		void sendAck(int recpAddress, unsigned long uniqueNumber);
+		void handleUnicast(std::unique_ptr<WaveShortMessage> wsm);
 		void handleAck(WaveShortMessageACK* ack);
 		void handleAckTimeOut(AckTimeOutMessage* ackTimeOutMsg);
 		void handleRetransmit(t_access_category ac);

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -217,8 +217,8 @@ class Mac1609_4 : public BaseMacLayer,
 
 		simtime_t getFrameDuration(int payloadLengthBits, enum PHY_MCS mcs = MCS_DEFAULT) const;
 
-		void sendACK(int recpAddress, unsigned long uniqueNumber);
-		void handleACK(WaveShortMessageACK* ack);
+		void sendAck(int recpAddress, unsigned long uniqueNumber);
+		void handleAck(WaveShortMessageACK* ack);
 		void handleAckTimeOut(AckTimeOutMessage* ackTimeOutMsg);
 		void handleRetransmit(t_access_category ac);
 	protected:
@@ -281,7 +281,7 @@ class Mac1609_4 : public BaseMacLayer,
 		/** @brief Id for debug messages */
 		std::string myId;
 
-		bool useACKs;
+		bool useAcks;
 		double ackErrorRate;
 		int dot11RTSThreshold;
 		int dot11ShortRetryLimit;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -220,7 +220,7 @@ class Mac1609_4 : public BaseMacLayer,
 
 		void sendAck(int recpAddress, unsigned long uniqueNumber);
 		void handleUnicast(std::unique_ptr<WaveShortMessage> wsm);
-		void handleAck(WaveShortMessageACK* ack);
+		void handleAck(std::unique_ptr<WaveShortMessageACK> ack);
 		void handleAckTimeOut(AckTimeOutMessage* ackTimeOutMsg);
 		void handleRetransmit(t_access_category ac);
 	protected:

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -218,7 +218,7 @@ class Mac1609_4 : public BaseMacLayer,
 
 		simtime_t getFrameDuration(int payloadLengthBits, enum PHY_MCS mcs = MCS_DEFAULT) const;
 
-		void sendAck(int recpAddress, unsigned long uniqueNumber);
+		void sendAck(int recpAddress, unsigned long wsmId);
 		void handleUnicast(std::unique_ptr<WaveShortMessage> wsm);
 		void handleAck(std::unique_ptr<WaveShortMessageACK> ack);
 		void handleAckTimeOut(AckTimeOutMessage* ackTimeOutMsg);

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -282,7 +282,6 @@ class Mac1609_4 : public BaseMacLayer,
 		std::string myId;
 
 		bool useACKs;
-		bool simulateErrorsInACK;
 		double ackErrorRate;
 		int dot11RTSThreshold;
 		int dot11ShortRetryLimit;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -199,6 +199,8 @@ class Mac1609_4 : public BaseMacLayer,
 		/** @brief Set a state for the channel selecting operation.*/
 		void setActiveChannel(t_channel state);
 
+		void sendFrame(Mac80211Pkt* frame, omnetpp::simtime_t delay, double frequency, uint64_t datarate, double txPower_mW);
+
 		simtime_t timeLeftInSlot() const;
 		simtime_t timeLeftTillGuardOver() const;
 

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -35,7 +35,7 @@
 #include "veins/modules/messages/Mac80211Pkt_m.h"
 #include "veins/modules/messages/WaveShortMessage_m.h"
 #include "veins/modules/messages/AckTimeOutMessage_m.h"
-#include "veins/modules/messages/WaveShortMessageACK_m.h"
+#include "veins/modules/messages/Mac80211Ack_m.h"
 #include "veins/base/modules/BaseMacLayer.h"
 
 #include "veins/modules/utility/ConstsPhy.h"
@@ -220,7 +220,7 @@ class Mac1609_4 : public BaseMacLayer,
 
 		void sendAck(int recpAddress, unsigned long wsmId);
 		void handleUnicast(std::unique_ptr<WaveShortMessage> wsm);
-		void handleAck(std::unique_ptr<WaveShortMessageACK> ack);
+		void handleAck(const Mac80211Ack* ack);
 		void handleAckTimeOut(AckTimeOutMessage* ackTimeOutMsg);
 		void handleRetransmit(t_access_category ac);
 	protected:
@@ -242,6 +242,9 @@ class Mac1609_4 : public BaseMacLayer,
 
 		/** @brief pointer to last sent packet */
 		WaveShortMessage* lastWSM;
+
+		/** @brief pointer to last sent mac frame */
+		std::unique_ptr<Mac80211Pkt> lastMac;
 
 		/** @brief Stores the frequencies in Hz that are associated to the channel numbers.*/
 		std::map<int,double> frequency;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
@@ -61,6 +61,15 @@ simple Mac1609_4 extends BaseMacLayer
         //the maximum queue size of an EDCA queue in the MAC. 0 for unlimited. Queue strategy is "drop if full"
         int queueSize = default(0);
 
+        // unicast parameters
+        int dot11RTSThreshold @unit(bit) = default(12000bit);
+        int dot11ShortRetryLimit = default(7);
+        int dot11LongRetryLimit = default(4);
+        int ackLength @unit(bit) = default(112bit);
+        bool useAcks = default(false);
+        bool simulateErrorsInACK = default(false);
+        double ackErrorRate = default(0.20);
+
         // signal informing interested application about channel busy state
         @signal[sigChannelBusy](type=bool);
         // signal informing interested application about a collision

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
@@ -67,7 +67,6 @@ simple Mac1609_4 extends BaseMacLayer
         int dot11LongRetryLimit = default(4);
         int ackLength @unit(bit) = default(112bit);
         bool useAcks = default(false);
-        bool simulateErrorsInACK = default(false);
         double ackErrorRate = default(0.20);
 
         // signal informing interested application about channel busy state

--- a/src/veins/modules/messages/AckTimeOutMessage.msg
+++ b/src/veins/modules/messages/AckTimeOutMessage.msg
@@ -19,8 +19,8 @@
 //
 
 message AckTimeOutMessage {
-    // Unique id which is same as the uniqueid assigned to unicast packet in mac
-    unsigned long uniqueId = -1;
+    // The corresponding WSM's tree id
+    unsigned long wsmId = -1;
     // Access category on which the AckTimer is set
     int ac = -1;
 }

--- a/src/veins/modules/messages/AckTimeOutMessage.msg
+++ b/src/veins/modules/messages/AckTimeOutMessage.msg
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2011 David Eckhoff <eckhoff@cs.fau.de>
+// Copyright (C) 2018 Gurjashan Pannu <pannu@ccs-labs.org>
 //
 // Documentation for these modules is at http://veins.car2x.org/
 //
@@ -18,33 +18,9 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //
 
-#ifndef MAC80211PTOPHY11PINTERFACE_H_
-#define MAC80211PTOPHY11PINTERFACE_H_
-
-#include "veins/base/phyLayer/MacToPhyInterface.h"
-
-/**
- * @brief
- * Interface of PhyLayer80211p exposed to Mac1609_4.
- *
- * @author Christopher Saloman
- * @author David Eckhoff
- *
- * @ingroup phyLayer
- */
-class Mac80211pToPhy11pInterface {
-	public:
-		enum BasePhyMessageKinds {
-			CHANNEL_IDLE,
-			CHANNEL_BUSY,
-		};
-
-	public:
-		virtual void changeListeningFrequency(double freq) = 0;
-		virtual void setCCAThreshold(double ccaThreshold_dBm) = 0;
-		virtual void notifyMacAboutRxStart(bool enable) = 0;
-		virtual void requestChannelStatusIfIdle() = 0;
-		virtual ~Mac80211pToPhy11pInterface() {};
-};
-
-#endif /* MAC80211PTOPHY11PINTERFACE_H_ */
+message AckTimeOutMessage {
+    // Unique id which is same as the uniqueid assigned to unicast packet in mac
+    unsigned long uniqueId = -1;
+    // Access category on which the AckTimer is set
+    int ac = -1;
+}

--- a/src/veins/modules/messages/Mac80211Ack.msg
+++ b/src/veins/modules/messages/Mac80211Ack.msg
@@ -19,12 +19,10 @@
 //
 
 cplusplus {{
-	#include "veins/modules/messages/WaveShortMessage_m.h"
+	#include "veins/modules/messages/Mac80211Pkt_m.h"
 }}
-class WaveShortMessage;
+class Mac80211Pkt;
 
-packet WaveShortMessageACK extends WaveShortMessage {
-    bool isAck = true;
-    // The corresponding WSM's tree id
-    unsigned long wsmId = -1;
+packet Mac80211Ack extends Mac80211Pkt {
+    unsigned long messageId; // The ID of the aknowledged packet
 }

--- a/src/veins/modules/messages/WaveShortMessage.msg
+++ b/src/veins/modules/messages/WaveShortMessage.msg
@@ -42,4 +42,8 @@ packet WaveShortMessage {
 	int recipientAddress = -1;
 	int serial = 0;
 	simtime_t timestamp = 0;
+
+	bool isUnicast = false;
+	// unique id (in simulation) assigned to the packet
+	unsigned long uniqueId = 0;
 }

--- a/src/veins/modules/messages/WaveShortMessage.msg
+++ b/src/veins/modules/messages/WaveShortMessage.msg
@@ -43,7 +43,6 @@ packet WaveShortMessage {
 	int serial = 0;
 	simtime_t timestamp = 0;
 
-	bool isUnicast = false;
 	// unique id (in simulation) assigned to the packet
 	unsigned long uniqueId = 0;
 }

--- a/src/veins/modules/messages/WaveShortMessage.msg
+++ b/src/veins/modules/messages/WaveShortMessage.msg
@@ -42,7 +42,4 @@ packet WaveShortMessage {
 	int recipientAddress = -1;
 	int serial = 0;
 	simtime_t timestamp = 0;
-
-	// unique id (in simulation) assigned to the packet
-	unsigned long uniqueId = 0;
 }

--- a/src/veins/modules/messages/WaveShortMessageACK.msg
+++ b/src/veins/modules/messages/WaveShortMessageACK.msg
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2011 David Eckhoff <eckhoff@cs.fau.de>
+// Copyright (C) 2018 Gurjashan Pannu <pannu@ccs-labs.org>
 //
 // Documentation for these modules is at http://veins.car2x.org/
 //
@@ -18,33 +18,11 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //
 
-#ifndef MAC80211PTOPHY11PINTERFACE_H_
-#define MAC80211PTOPHY11PINTERFACE_H_
+cplusplus {{
+	#include "veins/modules/messages/WaveShortMessage_m.h"
+}}
+class WaveShortMessage;
 
-#include "veins/base/phyLayer/MacToPhyInterface.h"
-
-/**
- * @brief
- * Interface of PhyLayer80211p exposed to Mac1609_4.
- *
- * @author Christopher Saloman
- * @author David Eckhoff
- *
- * @ingroup phyLayer
- */
-class Mac80211pToPhy11pInterface {
-	public:
-		enum BasePhyMessageKinds {
-			CHANNEL_IDLE,
-			CHANNEL_BUSY,
-		};
-
-	public:
-		virtual void changeListeningFrequency(double freq) = 0;
-		virtual void setCCAThreshold(double ccaThreshold_dBm) = 0;
-		virtual void notifyMacAboutRxStart(bool enable) = 0;
-		virtual void requestChannelStatusIfIdle() = 0;
-		virtual ~Mac80211pToPhy11pInterface() {};
-};
-
-#endif /* MAC80211PTOPHY11PINTERFACE_H_ */
+packet WaveShortMessageACK extends WaveShortMessage {
+    bool isAck = true;
+}

--- a/src/veins/modules/messages/WaveShortMessageACK.msg
+++ b/src/veins/modules/messages/WaveShortMessageACK.msg
@@ -25,4 +25,6 @@ class WaveShortMessage;
 
 packet WaveShortMessageACK extends WaveShortMessage {
     bool isAck = true;
+    // The corresponding WSM's tree id
+    unsigned long wsmId = -1;
 }

--- a/src/veins/modules/phy/Decider80211p.h
+++ b/src/veins/modules/phy/Decider80211p.h
@@ -119,6 +119,9 @@ class Decider80211p: public BaseDecider {
 		/** @brief count the number of collisions */
 		unsigned int collisions;
 
+		/** @brief notify PHY-RXSTART.indication  */
+		bool notifyRxStart;
+
 	protected:
 
 		/**
@@ -204,7 +207,8 @@ class Decider80211p: public BaseDecider {
 			myBusyTime(0),
 			myStartTime(simTime().dbl()),
 			collectCollisionStats(collectCollisionStatistics),
-			collisions(0) {
+			collisions(0),
+			notifyRxStart(false) {
 			phy11p = dynamic_cast<Decider80211pToPhy80211pInterface*>(phy);
 			assert(phy11p);
 
@@ -249,6 +253,11 @@ class Decider80211p: public BaseDecider {
 		 * because of the transmission.
 		 */
 		virtual void switchToTx();
+
+		/**
+		 * @brief notify PHY-RXSTART.indication
+		 */
+		void setNotifyRxStart(bool enable);
 
 };
 

--- a/src/veins/modules/phy/PhyLayer80211p.cc
+++ b/src/veins/modules/phy/PhyLayer80211p.cc
@@ -487,3 +487,17 @@ void PhyLayer80211p::setCCAThreshold(double ccaThreshold_dBm) {
 double PhyLayer80211p::getCCAThreshold() {
 	return 10 * log10(ccaThreshold);
 }
+
+void PhyLayer80211p::notifyMacAboutRxStart(bool enable) {
+    ((Decider80211p *)decider)->setNotifyRxStart(enable);
+}
+
+void PhyLayer80211p::requestChannelStatusIfIdle() {
+    Enter_Method_Silent();
+    Decider80211p* dec = (Decider80211p*)decider;
+    if (dec->cca(simTime(),NULL)) {
+        //chan is idle
+        DBG << "Request channel status: channel idle!\n";
+        dec->setChannelIdleStatus(true);
+    }
+}

--- a/src/veins/modules/phy/PhyLayer80211p.h
+++ b/src/veins/modules/phy/PhyLayer80211p.h
@@ -66,6 +66,15 @@ class PhyLayer80211p	: 	public BasePhyLayer,
 		 * @brief Return the cca threshold in dBm
 		 */
 		double getCCAThreshold();
+		/**
+		 * @brief Enable notifications about PHY-RXSTART.indication in MAC
+		 * @param val true if Mac needs to be notified about it
+		 */
+		void notifyMacAboutRxStart(bool enable);
+		/**
+		 * @brief Explicit request to PHY for the channel status
+		 */
+		void requestChannelStatusIfIdle();
 	protected:
 
 		/** @brief CCA threshold. See Decider80211p for details */


### PR DESCRIPTION
This PR builds on #55 which adds unicast support to the MAC. It does most of the work, This is just a few additions to tidy the code up a bit. The changes are mostly non-functional (e.g. delgate code to helpers) with a few exceptions:
- Acknowledgement messages are based MAC instead of WAVE messages
- Dropped support for simulating missed ACKs
- Removed example for integration with master
- Add statistics for sent acknowledgements