### PR TITLE
Fix compile warning

### DIFF
--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -134,7 +134,7 @@ class Mac1609_4 : public BaseMacLayer,
 		};
 
 	public:
-		Mac1609_4() : nextMacEvent(nullptr), nextChannelSwitch(nullptr) {}
+		Mac1609_4() : nextChannelSwitch(nullptr), nextMacEvent(nullptr) {}
 		~Mac1609_4();
 
 		/**


### PR DESCRIPTION
Unfortunately, in f5a3feb3ef88d8ee478e13bde9846d2444a4cedf a compile warning about the order of member initialization was introduced. This commit fixes it.