### PR TITLE
Enable undisposed printing

### DIFF
--- a/examples/veins/omnetpp.ini
+++ b/examples/veins/omnetpp.ini
@@ -13,7 +13,7 @@ network = RSUExampleScenario
 #            Simulation parameters                       #
 ##########################################################
 debug-on-errors = true
-print-undisposed = false
+print-undisposed = true
 
 sim-time-limit = 200s
 


### PR DESCRIPTION
Due to disabled undisposed printing potential memory leaks might not be
recognized.
This commit enables the printing of undisposed objects in OMNeT++ to
help developers recognizing those leaks.

See issue #63 for an example.