### PR TITLE
Add check for internal egde/lane

### DIFF
--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <stdlib.h>
 
 #include "veins/modules/mobility/traci/TraCIBuffer.h"
@@ -104,6 +105,13 @@ double TraCICommandInterface::Road::getCurrentTravelTime() {
 
 double TraCICommandInterface::Road::getMeanSpeed() {
 	return traci->genericGetDouble(CMD_GET_EDGE_VARIABLE, roadId, LAST_STEP_MEAN_SPEED, RESPONSE_GET_EDGE_VARIABLE);
+}
+
+const std::string TraCICommandInterface::Road::internalPrefix = ":";
+
+bool TraCICommandInterface::Road::isInternal() const {
+	const auto prefixStart = std::mismatch(internalPrefix.begin(), internalPrefix.end(), roadId.begin()).first;
+	return (prefixStart == internalPrefix.end());
 }
 
 std::string TraCICommandInterface::Vehicle::getRoadId() {
@@ -505,6 +513,13 @@ double TraCICommandInterface::Lane::getMaxSpeed() {
 
 double TraCICommandInterface::Lane::getMeanSpeed() {
 	return traci->genericGetDouble(CMD_GET_LANE_VARIABLE, laneId, LAST_STEP_MEAN_SPEED, RESPONSE_GET_LANE_VARIABLE);
+}
+
+const std::string TraCICommandInterface::Lane::internalPrefix = ":";
+
+bool TraCICommandInterface::Lane::isInternal() const {
+	const auto prefixStart = std::mismatch(internalPrefix.begin(), internalPrefix.end(), laneId.begin()).first;
+	return (prefixStart == internalPrefix.end());
 }
 
 std::list<std::string> TraCICommandInterface::getJunctionIds() {

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -110,11 +110,15 @@ class TraCICommandInterface
 
 				double getCurrentTravelTime();
 				double getMeanSpeed();
+				bool isInternal() const;
 
 			protected:
 				TraCICommandInterface* traci;
 				TraCIConnection* connection;
 				std::string roadId;
+
+			private:
+				static const std::string internalPrefix;
 		};
 		Road road(std::string roadId) {
 			return Road(this, roadId);
@@ -133,11 +137,15 @@ class TraCICommandInterface
 				double getLength();
 				double getMaxSpeed();
 				double getMeanSpeed();
+				bool isInternal() const;
 
 			protected:
 				TraCICommandInterface* traci;
 				TraCIConnection* connection;
 				std::string laneId;
+
+			private:
+				static const std::string internalPrefix;
 		};
 		Lane lane(std::string laneId) {
 			return Lane(this, laneId);


### PR DESCRIPTION
Sumo creates internal edges/lanes for instance on merge nodes. Internal edges are prefixed with a colon. This commit provides helper functions for finding out whether an edge/lane is internal (i.e. prefixed with a colon).