### PR TITLE
Rework traci connection cleanup

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -54,6 +54,9 @@ TraCIScenarioManager::TraCIScenarioManager() :
 }
 
 TraCIScenarioManager::~TraCIScenarioManager() {
+	if (connection) {
+		TraCIBuffer buf = connection->query(CMD_CLOSE, TraCIBuffer());
+	}
 	cancelAndDelete(connectAndStartTrigger);
 	cancelAndDelete(executeOneTimestepTrigger);
 }
@@ -476,9 +479,6 @@ void TraCIScenarioManager::init_traci() {
 }
 
 void TraCIScenarioManager::finish() {
-	if (connection) {
-		TraCIBuffer buf = connection->query(CMD_CLOSE, TraCIBuffer());
-	}
 	while (hosts.begin() != hosts.end()) {
 		deleteManagedModule(hosts.begin()->first);
 	}

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -43,7 +43,8 @@ const std::string TraCIScenarioManager::TRACI_INITIALIZED_SIGNAL_NAME = "traciIn
 
 TraCIScenarioManager::TraCIScenarioManager() :
 		mobRng(0),
-		connection(0),
+		connection(nullptr),
+		commandIfc(nullptr),
 		connectAndStartTrigger(0),
 		executeOneTimestepTrigger(0),
 		world(0),
@@ -55,8 +56,6 @@ TraCIScenarioManager::TraCIScenarioManager() :
 TraCIScenarioManager::~TraCIScenarioManager() {
 	cancelAndDelete(connectAndStartTrigger);
 	cancelAndDelete(executeOneTimestepTrigger);
-	delete commandIfc;
-	delete connection;
 }
 
 std::vector<std::string> getMapping(std::string el) {
@@ -497,8 +496,8 @@ void TraCIScenarioManager::handleMessage(cMessage *msg) {
 
 void TraCIScenarioManager::handleSelfMsg(cMessage *msg) {
 	if (msg == connectAndStartTrigger) {
-		connection = TraCIConnection::connect(host.c_str(), port);
-		commandIfc = new TraCICommandInterface(*connection);
+		connection.reset(TraCIConnection::connect(host.c_str(), port));
+		commandIfc.reset(new TraCICommandInterface(*connection));
 		init_traci();
 		return;
 	}

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -22,6 +22,7 @@
 #define VEINS_WORLD_TRACI_TRACISCENARIOMANAGER_H
 
 #include <map>
+#include <memory>
 #include <list>
 #include <queue>
 
@@ -91,9 +92,9 @@ class TraCIScenarioManager : public cSimpleModule
 		virtual void handleMessage(cMessage *msg);
 		virtual void handleSelfMsg(cMessage *msg);
 
-		bool isConnected() const { return (connection); }
+		bool isConnected() const { return static_cast<bool>(connection); }
 
-		TraCICommandInterface* getCommandInterface() const { return commandIfc; }
+		TraCICommandInterface* getCommandInterface() const { return commandIfc.get(); }
 
 		bool getAutoShutdownTriggered() {
 			return autoShutdownTriggered;
@@ -139,8 +140,8 @@ class TraCIScenarioManager : public cSimpleModule
 		double areaSum;
 
 		AnnotationManager* annotations;
-		TraCIConnection* connection;
-		TraCICommandInterface* commandIfc;
+		std::unique_ptr<TraCIConnection> connection;
+		std::unique_ptr<TraCICommandInterface> commandIfc;
 
 		size_t nextNodeVectorIndex; /**< next OMNeT++ module vector index to use */
 		std::map<std::string, cModule*> hosts; /**< vector of all hosts managed by us */


### PR DESCRIPTION
This patchset changes two things:
- Use smart pointers for plain C++ objects owned by the TraCIScenarioManager
- Move the cleanup of the traci connection to TraCIScenarioManager's dtor instead of its finish method. This change allows modules to rely on the traci connection during their finish methods, which was previously only the case for modules that get deleted prior to the simulation ending, e.g. due to teleporting or leaving the ROI. Therefore, it is now possible to record statistics in finish that use traci, such as the CO2 emissions.