### PR TITLE
simplify ScenarioManager with getSubmoduleByType<T> helper

### DIFF
--- a/src/veins/base/utils/FindModule.h
+++ b/src/veins/base/utils/FindModule.h
@@ -105,6 +105,20 @@ public:
     }
 };
 
+/**
+ * @brief Return a vector containing pointers to all submodules of parentModule of type T
+ */
+template <class T>
+std::vector<T*> getSubmodulesOfType(cModule* parentModule)
+{
+    std::vector<T*> result;
+    for (cModule::SubmoduleIterator iter(parentModule); !iter.end(); iter++) {
+        auto mm = dynamic_cast<T*>(*iter);
+        if (mm != nullptr) result.push_back(mm);
+    }
+    return result;
+}
+
 } // namespace Veins
 
 #endif

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -552,10 +552,8 @@ void TraCIScenarioManager::handleSelfMsg(cMessage* msg)
 void TraCIScenarioManager::preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, double angle, VehicleSignal signals)
 {
     // pre-initialize TraCIMobility
-    for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
-        cModule* submod = *iter;
-        TraCIMobility* mm = dynamic_cast<TraCIMobility*>(submod);
-        if (!mm) continue;
+    auto mobilityModules = getSubmodulesOfType<TraCIMobility>(mod);
+    for (auto mm : mobilityModules) {
         mm->preInitialize(nodeId, position, road_id, speed, angle);
     }
 }
@@ -563,10 +561,8 @@ void TraCIScenarioManager::preInitializeModule(cModule* mod, const std::string& 
 void TraCIScenarioManager::updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, double angle, VehicleSignal signals)
 {
     // update position in TraCIMobility
-    for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
-        cModule* submod = *iter;
-        TraCIMobility* mm = dynamic_cast<TraCIMobility*>(submod);
-        if (!mm) continue;
+    auto mobilityModules = getSubmodulesOfType<TraCIMobility>(mod);
+    for (auto mm : mobilityModules) {
         mm->nextPosition(p, edge, speed, angle, signals);
     }
 }
@@ -611,10 +607,8 @@ void TraCIScenarioManager::addModule(std::string nodeId, std::string type, std::
     hosts[nodeId] = mod;
 
     // post-initialize TraCIMobility
-    for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
-        cModule* submod = *iter;
-        TraCIMobility* mm = dynamic_cast<TraCIMobility*>(submod);
-        if (!mm) continue;
+    auto mobilityModules = getSubmodulesOfType<TraCIMobility>(mod);
+    for (auto mm : mobilityModules) {
         mm->changePosition();
     }
 }
@@ -953,10 +947,8 @@ void TraCIScenarioManager::processSimSubscription(std::string objectId, TraCIBuf
                 buf >> idstring;
 
                 cModule* mod = getManagedModule(idstring);
-                for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
-                    cModule* submod = *iter;
-                    TraCIMobility* mm = dynamic_cast<TraCIMobility*>(submod);
-                    if (!mm) continue;
+                auto mobilityModules = getSubmodulesOfType<TraCIMobility>(mod);
+                for (auto mm : mobilityModules) {
                     mm->changeParkingState(true);
                 }
             }
@@ -976,10 +968,8 @@ void TraCIScenarioManager::processSimSubscription(std::string objectId, TraCIBuf
                 buf >> idstring;
 
                 cModule* mod = getManagedModule(idstring);
-                for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
-                    cModule* submod = *iter;
-                    TraCIMobility* mm = dynamic_cast<TraCIMobility*>(submod);
-                    if (!mm) continue;
+                auto mobilityModules = getSubmodulesOfType<TraCIMobility>(mod);
+                for (auto mm : mobilityModules) {
                     mm->changeParkingState(false);
                 }
             }

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
@@ -33,10 +33,8 @@ VeinsInetManager::~VeinsInetManager()
 void VeinsInetManager::preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, double angle, VehicleSignal signals)
 {
     // pre-initialize VeinsInetMobility
-    for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
-        cModule* submod = *iter;
-        VeinsInetMobility* inetmm = dynamic_cast<VeinsInetMobility*>(submod);
-        if (!inetmm) return;
+    auto mobilityModules = getSubmodulesOfType<VeinsInetMobility>(mod);
+    for (auto inetmm : mobilityModules) {
         inetmm->preInitialize(nodeId, inet::Coord(position.x, position.y), road_id, speed, angle);
     }
 }
@@ -44,10 +42,8 @@ void VeinsInetManager::preInitializeModule(cModule* mod, const std::string& node
 void VeinsInetManager::updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, double angle, VehicleSignal signals)
 {
     // update position in VeinsInetMobility
-    for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
-        cModule* submod = *iter;
-        VeinsInetMobility* inetmm = dynamic_cast<VeinsInetMobility*>(submod);
-        if (!inetmm) return;
+    auto mobilityModules = getSubmodulesOfType<VeinsInetMobility>(mod);
+    for (auto inetmm : mobilityModules) {
         inetmm->nextPosition(inet::Coord(p.x, p.y), edge, speed, angle);
     }
 }


### PR DESCRIPTION
Accessing all submodules of a certain type (e.g., mobility submodules) of a compound module is a repeated pattern in the scenario manager's code. This PR introduces a helper method that simplifies this pattern.
Adaptions for the TraCIScenarioManager and the VeinsInetManager veins_inet are included.