### PR TITLE
Additional TraCI commands and missing header

### DIFF
--- a/src/veins/base/utils/asserts.h
+++ b/src/veins/base/utils/asserts.h
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <stdlib.h>
 #include <math.h>
+#include <limits>
 
 extern bool haltOnFails;
 extern bool displayPassed;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -241,6 +241,18 @@ double TraCICommandInterface::Vehicle::getLength()
     return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_LENGTH, RESPONSE_GET_VEHICLE_VARIABLE);
 }
 
+double TraCICommandInterface::Vehicle::getWidth() {
+    return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_WIDTH, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
+double TraCICommandInterface::Vehicle::getAccel() {
+    return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_ACCEL, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
+double TraCICommandInterface::Vehicle::getDeccel() {
+    return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_DECEL, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
 double TraCICommandInterface::Vehicle::getCO2Emissions() const
 {
     return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_CO2EMISSION, RESPONSE_GET_VEHICLE_VARIABLE);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -102,7 +102,9 @@ public:
         std::string getTypeId();
         bool changeVehicleRoute(const std::list<std::string>& roads);
         double getLength();
-
+        double getWidth();
+        double getAccel();
+        double getDeccel();
         /**
          * Get the vehicle's CO2 emissions in mg during this time step.
          *


### PR DESCRIPTION
I have added three Traci commands add getWidth, getAccel, getDeccel which can be helpful for safety application and a missing header in asserts.h