### PR TITLE
Fix tests gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tests/**/.tkenvrc
 tests/**/.qtenvrc
 tests/**/out.tmp
 tests/**/err.tmp
+tests/**/.cmdenv-log
 
 examples/**/results
 examples/**/.tkenvrc


### PR DESCRIPTION
The current `gitignore` does not handle cmdenv log output in the `tests` subdirectories.