### PR TITLE
Improve float equality check

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,3 @@
-Veins 4.8:
-* Rework float comparison to work well for larger numbers (Add Veins::math::almost_equal, deprecate Veins::FWMath::close).
-
-
 Veins 2.1-bis:
 
 + Veins is now a fork of MiXiM (instead of a very long patch). 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+Veins 4.8:
+* Rework float comparison to work well for larger numbers (Add Veins::math::almost_equal, deprecate Veins::FWMath::close).
+
+
 Veins 2.1-bis:
 
 + Veins is now a fork of MiXiM (instead of a very long patch). 

--- a/src/veins/base/connectionManager/BaseConnectionManager.cc
+++ b/src/veins/base/connectionManager/BaseConnectionManager.cc
@@ -125,7 +125,7 @@ void BaseConnectionManager::initialize(int stage)
         // (the last) grid cell we do this by increasing the find distance
         // by a small value.
         // This also assures that findDistance is never zero.
-        findDistance += Coord(EPSILON, EPSILON, EPSILON);
+        findDistance += Coord(std::numeric_limits<double>::epsilon(), std::numeric_limits<double>::epsilon(), std::numeric_limits<double>::epsilon());
 
         // findDistance (equals cell size) has to be greater or equal
         // maxInt-distance

--- a/src/veins/base/connectionManager/BaseConnectionManager.cc
+++ b/src/veins/base/connectionManager/BaseConnectionManager.cc
@@ -125,7 +125,8 @@ void BaseConnectionManager::initialize(int stage)
         // (the last) grid cell we do this by increasing the find distance
         // by a small value.
         // This also assures that findDistance is never zero.
-        findDistance += Coord(std::numeric_limits<double>::epsilon(), std::numeric_limits<double>::epsilon(), std::numeric_limits<double>::epsilon());
+        const auto epsilon = std::numeric_limits<double>::epsilon();
+        findDistance += Coord(epsilon, epsilon, epsilon);
 
         // findDistance (equals cell size) has to be greater or equal
         // maxInt-distance

--- a/src/veins/base/utils/Coord.h
+++ b/src/veins/base/utils/Coord.h
@@ -175,7 +175,7 @@ public:
      * @brief Tests whether two coordinate vectors are equal.
      *
      * Because coordinates are floating point values, this is done using an epsilon comparison.
-	 * @see math::almost_equal
+     * @see math::almost_equal
      *
      */
     friend bool operator==(const Coord& a, const Coord& b)

--- a/src/veins/base/utils/Coord.h
+++ b/src/veins/base/utils/Coord.h
@@ -174,13 +174,14 @@ public:
     /**
      * @brief Tests whether two coordinate vectors are equal.
      *
-     * Because coordinates are of type double, this is done through the
-     * FWMath::close function.
+     * Because coordinates are floating point values, this is done using an epsilon comparison.
+	 * @see math::almost_equal
+     *
      */
     friend bool operator==(const Coord& a, const Coord& b)
     {
         // FIXME: this implementation is not transitive
-        return FWMath::close(a.x, b.x) && FWMath::close(a.y, b.y) && FWMath::close(a.z, b.z);
+        return math::almost_equal(a.x, b.x) && math::almost_equal(a.y, b.y) && math::almost_equal(a.z, b.z);
     }
 
     /**

--- a/src/veins/base/utils/FWMath.h
+++ b/src/veins/base/utils/FWMath.h
@@ -24,7 +24,11 @@
 // Support functions for mathematical operations
 //
 
-#include <math.h>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+#include "veins/base/utils/veins.h"
 #include "veins/base/utils/MiXiMDefs.h"
 
 namespace Veins {
@@ -88,6 +92,35 @@ namespace Veins {
 #define EPSILON 0.001
 #endif
 
+namespace math {
+
+/**
+ * Compare two floats for approximate equality
+ *
+ * Floating point numbers are prone to inequalities. Expressions that logically
+ * result in the same values therefore often are not exactly equal, because two
+ * representations of very similar values are computed. This function allows
+ * comparisons for such cases by allowing for a small error (epsilon), without
+ * considering numbers to be unequal.
+ *
+ * \param lhs First comparand
+ * \param rhs Second comparand
+ * \param ulp How many ULP's (Units in the Last Place) we want to tolerate when
+ * 		comparing two numbers. The larger the value, the more error we allow.
+ * 		The maximum floating point error on most platforms is below 0.5 ULP.
+ * 		A 0 value means that two numbers must be exactly the same to be
+ * 		considered equal.
+ * \return Indicator whether the lhs and rhs are virtually equal
+ */
+template <class T>
+typename std::enable_if<std::is_floating_point<T>::value, bool>::type
+almost_equal(T x, T y, int ulp = 1)
+{
+    return (std::abs(x - y) <= std::numeric_limits<T>::epsilon() * std::abs(x + y) * ulp || std::abs(x - y) < std::numeric_limits<T>::min());
+}
+
+} // namespace math
+
 /**
  * @brief Support functions for mathematical operations.
  *
@@ -132,8 +165,11 @@ public:
      * Tests whether two doubles are close enough to be declared equal.
      * Returns true if parameters are at most epsilon apart, false
      * otherwise
+	 *
+	 * @deprecated Since 4.8
+	 * @see Veins::math::almost_equal
      */
-    static bool close(double one, double two)
+    VEINS_DEPRECATED static bool close(double one, double two)
     {
         return fabs(one - two) < EPSILON;
     }
@@ -144,7 +180,17 @@ public:
      */
     static int stepfunction(double i)
     {
-        return (i > EPSILON) ? 1 : close(i, 0) ? 0 : -1;
+        if (math::almost_equal<double>(i, 0)) {
+            return 0;
+        }
+        else {
+            if (std::signbit(i) == 1) {
+                return -1;
+            }
+            else {
+                return 1;
+            }
+        }
     };
 
     /**

--- a/src/veins/base/utils/FWMath.h
+++ b/src/veins/base/utils/FWMath.h
@@ -97,26 +97,26 @@ namespace math {
 /**
  * Compare two floats for approximate equality
  *
- * Floating point numbers are prone to inequalities. Expressions that logically
- * result in the same values therefore often are not exactly equal, because two
- * representations of very similar values are computed. This function allows
- * comparisons for such cases by allowing for a small error (epsilon), without
- * considering numbers to be unequal.
+ * Floating point numbers are prone to inequalities.
+ * Expressions that logically result in the same values therefore often are not exactly equal, because two representations of very similar values are computed.
+ * This function allows comparisons for such cases by allowing for a small error (epsilon), without considering numbers to be unequal.
  *
- * \param lhs First comparand
- * \param rhs Second comparand
- * \param ulp How many ULP's (Units in the Last Place) we want to tolerate when
- * 		comparing two numbers. The larger the value, the more error we allow.
- * 		The maximum floating point error on most platforms is below 0.5 ULP.
- * 		A 0 value means that two numbers must be exactly the same to be
- * 		considered equal.
- * \return Indicator whether the lhs and rhs are virtually equal
+ * @param lhs First comparand
+ * @param rhs Second comparand
+ * @param ulp
+ *      How many ULP's (Units in the Last Place) we want to tolerate when comparing two numbers.
+ *      The larger the value, the more error we allow.
+ *      The maximum floating point error on most platforms is below 0.5 ULP.
+ *      A 0 value means that two numbers must be exactly the same to be considered equal.
+ * @return Indicator whether the lhs and rhs are virtually equal
  */
 template <class T>
 typename std::enable_if<std::is_floating_point<T>::value, bool>::type
 almost_equal(T x, T y, int ulp = 1)
 {
-    return (std::abs(x - y) <= std::numeric_limits<T>::epsilon() * std::abs(x + y) * ulp || std::abs(x - y) < std::numeric_limits<T>::min());
+    const T epsilon = std::numeric_limits<T>::epsilon();
+    const T delta = std::abs(x - y);
+    return (delta <= epsilon * std::abs(x + y) * ulp) || (delta < std::numeric_limits<T>::min());
 }
 
 } // namespace math
@@ -165,9 +165,9 @@ public:
      * Tests whether two doubles are close enough to be declared equal.
      * Returns true if parameters are at most epsilon apart, false
      * otherwise
-	 *
-	 * @deprecated Since 4.8
-	 * @see Veins::math::almost_equal
+     *
+     * @deprecated
+     * @see Veins::math::almost_equal
      */
     VEINS_DEPRECATED static bool close(double one, double two)
     {
@@ -183,14 +183,14 @@ public:
         if (math::almost_equal<double>(i, 0)) {
             return 0;
         }
-        else {
-            if (std::signbit(i) == 1) {
-                return -1;
-            }
-            else {
-                return 1;
-            }
+
+        if (std::signbit(i) == 1) {
+            return -1;
         }
+        else {
+            return 1;
+        }
+
     };
 
     /**

--- a/src/veins/base/utils/Move.h
+++ b/src/veins/base/utils/Move.h
@@ -159,7 +159,7 @@ public:
      */
     void setDirectionByVector(const Coord& direction)
     {
-        assert(FWMath::close(direction.squareLength(), 1.0) || FWMath::close(direction.squareLength(), 0.0));
+        assert(math::almost_equal(direction.squareLength(), 1.0) || math::almost_equal(direction.squareLength(), 0.0));
         this->direction = direction;
 
         // only if one of the x or y components is nonzero, also set orientation to
@@ -180,7 +180,7 @@ public:
     {
         direction = target - startPos;
 
-        assert(!FWMath::close(direction.length(), 0.0));
+        assert(!math::almost_equal(direction.length(), 0.0));
         direction /= direction.length();
 
         // only if one of the x or y components is nonzero, also set orientation to
@@ -203,7 +203,7 @@ public:
     virtual Coord getPositionAt(simtime_t_cref actualTime = simTime()) const
     {
         // if speed is very close to 0.0, the host is practically standing still
-        if (FWMath::close(speed, 0.0)) return startPos;
+        if (math::almost_equal(speed, 0.0)) return startPos;
 
         // otherwise: actualPos = startPos + ( direction * v * t )
         return startPos + (direction * speed * SIMTIME_DBL(actualTime - startTime));

--- a/src/veins/base/utils/asserts.h
+++ b/src/veins/base/utils/asserts.h
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <limits>
 #include <string>
 #include <sstream>
 #include <stdlib.h>

--- a/src/veins/base/utils/veins.h
+++ b/src/veins/base/utils/veins.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <omnetpp.h>
+
+#define VEINS_DEPRECATED _OPP_DEPRECATED

--- a/src/veins/base/utils/veins.h
+++ b/src/veins/base/utils/veins.h
@@ -2,4 +2,4 @@
 
 #include <omnetpp.h>
 
-#define VEINS_DEPRECATED _OPP_DEPRECATED
+#define VEINS_DEPRECATED _OPPDEPRECATED

--- a/src/veins/modules/phy/SampledAntenna1D.cc
+++ b/src/veins/modules/phy/SampledAntenna1D.cc
@@ -34,19 +34,19 @@ SampledAntenna1D::SampledAntenna1D(std::vector<double>& values, std::string offs
     // instantiate a random number generator for sample offsets if one is specified
     cRandom* offsetGen = 0;
     if (offsetType == "uniform") {
-        if (!FWMath::close(offsetParams[0], -offsetParams[1])) {
+        if (!math::almost_equal(offsetParams[0], -offsetParams[1])) {
             throw cRuntimeError("SampledAntenna1D::SampledAntenna1D(): The mean of the random distribution for the samples' offsets has to be 0.");
         }
         offsetGen = new cUniform(rng, offsetParams[0], offsetParams[1]);
     }
     else if (offsetType == "normal") {
-        if (!FWMath::close(offsetParams[0], 0)) {
+        if (!math::almost_equal<double>(offsetParams[0], 0)) {
             throw cRuntimeError("SampledAntenna1D::SampledAntenna1D(): The mean of the random distribution for the samples' offsets has to be 0.");
         }
         offsetGen = new cNormal(rng, offsetParams[0], offsetParams[1]);
     }
     else if (offsetType == "triang") {
-        if (!FWMath::close((offsetParams[0] + offsetParams[1] + offsetParams[2]) / 3, 0)) {
+        if (!math::almost_equal<double>((offsetParams[0] + offsetParams[1] + offsetParams[2]) / 3, 0)) {
             throw cRuntimeError("SampledAntenna1D::SampledAntenna1D(): The mean of the random distribution for the samples' offsets has to be 0.");
         }
         offsetGen = new cTriang(rng, offsetParams[0], offsetParams[1], offsetParams[2]);


### PR DESCRIPTION
The current helper for float equality checks does deliver false negatives for numbers that are too large. This PR introduces a new helper that doesn't suffer from these issues and deprecates the old one.