### PR TITLE
add missing omnet include in 802.11p consts

### DIFF
--- a/src/veins/modules/utility/Consts80211p.h
+++ b/src/veins/modules/utility/Consts80211p.h
@@ -21,7 +21,10 @@
 #ifndef CONSTANTS_802_11p
 #define CONSTANTS_802_11p
 
+#include <omnetpp.h>
 #include <stdint.h>
+
+using omnetpp::SimTime;
 
 /** @brief Bit rates for 802.11p
  *


### PR DESCRIPTION
The Consts80211p.h file uses SimTime objects but did neither import the omnet header nor qualify their namespace.