### PR TITLE
Support for Sumo Version 1.0 and 0.32 / 0.30

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIBuffer.cc
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.cc
@@ -7,6 +7,8 @@
 
 namespace Veins {
 
+bool TraCIBuffer::timeAsDouble = true;
+
 TraCIBuffer::TraCIBuffer()
     : buf()
 {
@@ -109,16 +111,29 @@ TraCICoord TraCIBuffer::read()
 template <>
 void TraCIBuffer::write(simtime_t o)
 {
-    double d = o.dbl();
-    write<double>(d);
+    if(timeAsDouble) {
+        double d = o.dbl();
+        write<double>(d);
+    }
+    else {
+        uint32_t i = o.inUnit(SIMTIME_MS);
+        write<uint32_t>(i);
+    }
 }
 
 template <>
 simtime_t TraCIBuffer::read()
 {
-    double d = read<double>();
-    simtime_t o = d;
-    return o;
+    if(timeAsDouble) {
+        double d = read<double>();
+        simtime_t o = d;
+        return o;
+    }
+    else {
+        uint32_t i = read<uint32_t>();
+        simtime_t o = SimTime(i, SIMTIME_MS);
+        return o;
+    }
 }
 
 bool isBigEndian()

--- a/src/veins/modules/mobility/traci/TraCIBuffer.h
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.h
@@ -114,9 +114,12 @@ public:
     std::string str() const;
     std::string hexStr() const;
 
+    static void setTimeAsDouble(bool val) { timeAsDouble = val; }
+
 private:
     std::string buf;
     size_t buf_index;
+    static bool timeAsDouble;
 };
 
 template <>

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -12,6 +12,13 @@
 
 namespace Veins {
 
+const std::map<uint32_t, TraCICommandInterface::VersionConfig> TraCICommandInterface::versionConfigs = {
+    {18, {TYPE_DOUBLE, TYPE_POLYGON, VAR_TIME, true}},
+    {17, {TYPE_INTEGER, TYPE_BOUNDINGBOX, VAR_TIME_STEP, false}},
+    {16, {TYPE_INTEGER, TYPE_BOUNDINGBOX, VAR_TIME_STEP, false}},
+    {15, {TYPE_INTEGER, TYPE_BOUNDINGBOX, VAR_TIME_STEP, false}},
+};
+
 TraCICommandInterface::TraCICommandInterface(TraCIConnection& c)
     : connection(c)
 {
@@ -39,6 +46,17 @@ std::pair<uint32_t, std::string> TraCICommandInterface::getVersion()
     ASSERT(buf.eof());
 
     return std::pair<uint32_t, std::string>(apiVersion, serverVersion);
+}
+
+void TraCICommandInterface::setApiVersion(uint32_t apiVersion)
+{
+    try {
+        versionConfig = versionConfigs.at(apiVersion);
+        TraCIBuffer::setTimeAsDouble(versionConfig.timeAsDouble);
+    }
+    catch (std::out_of_range const& exc) {
+        throw cRuntimeError(std::string("TraCI server reports unsupported TraCI API version: " + std::to_string(apiVersion) + ". We recommend using Sumo version 1.0.1 or 0.32.0").c_str());
+    }
 }
 
 void TraCICommandInterface::Vehicle::setSpeedMode(int32_t bitset)

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -46,7 +46,12 @@ public:
 
     // General methods that do not deal with a particular object in the simulation
     std::pair<uint32_t, std::string> getVersion();
+    void setApiVersion(uint32_t apiVersion);
     std::pair<double, double> getLonLat(const Coord&);
+
+    uint8_t getTimeType() const { return versionConfig.timeType; }
+    uint8_t getNetBoundaryType() const { return versionConfig.netBoundaryType; }
+    uint8_t getTimeStepCmd() const { return versionConfig.timeStepCmd; }
 
     /**
      * Get the distance between two arbitrary positions.
@@ -407,7 +412,16 @@ public:
     }
 
 private:
+    struct VersionConfig {
+        uint8_t timeType;
+        uint8_t netBoundaryType;
+        uint8_t timeStepCmd;
+        bool timeAsDouble;
+    };
+
     TraCIConnection& connection;
+    static const std::map<uint32_t, VersionConfig> versionConfigs;
+    VersionConfig versionConfig;
 
     std::string genericGetString(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId);
     Coord genericGetCoord(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -7,6 +7,7 @@
 
 #include "veins/modules/mobility/traci/TraCIColor.h"
 #include "veins/base/utils/Coord.h"
+#include "veins/modules/mobility/traci/TraCICoord.h"
 #include "veins/modules/world/traci/trafficLight/TraCITrafficLightProgram.h"
 
 namespace Veins {
@@ -52,6 +53,8 @@ public:
     uint8_t getTimeType() const { return versionConfig.timeType; }
     uint8_t getNetBoundaryType() const { return versionConfig.netBoundaryType; }
     uint8_t getTimeStepCmd() const { return versionConfig.timeStepCmd; }
+
+    std::pair<TraCICoord, TraCICoord> initNetworkBoundaries(int margin);
 
     /**
      * Get the distance between two arbitrary positions.

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -315,55 +315,18 @@ void TraCIScenarioManager::initialize(int stage)
 
 void TraCIScenarioManager::init_traci()
 {
+    auto* commandInterface = getCommandInterface();
     {
-        std::pair<uint32_t, std::string> version = getCommandInterface()->getVersion();
-        uint32_t apiVersion = version.first;
-        std::string serverVersion = version.second;
-
-        const std::vector<uint32_t> allowedVersions({18});
-
-        if (std::find(allowedVersions.begin(), allowedVersions.end(), apiVersion) == allowedVersions.end()) {
-            error("TraCI server \"%s\" reports API version %d, which is unsupported. We recommend using SUMO 1.0.0", serverVersion.c_str(), apiVersion);
-        }
-
-        EV_DEBUG << "TraCI server \"" << serverVersion << "\" reports API version " << apiVersion << endl;
+        auto apiVersion = commandInterface->getVersion();
+        EV_DEBUG << "TraCI server \"" << apiVersion.second << "\" reports API version " << apiVersion.first << endl;
+        commandInterface->setApiVersion(apiVersion.first);
     }
 
     {
-        // query road network boundaries
-        TraCIBuffer buf = connection->query(CMD_GET_SIM_VARIABLE, TraCIBuffer() << static_cast<uint8_t>(VAR_NET_BOUNDING_BOX) << std::string("sim0"));
-        uint8_t cmdLength_resp;
-        buf >> cmdLength_resp;
-        uint8_t commandId_resp;
-        buf >> commandId_resp;
-        ASSERT(commandId_resp == RESPONSE_GET_SIM_VARIABLE);
-        uint8_t variableId_resp;
-        buf >> variableId_resp;
-        ASSERT(variableId_resp == VAR_NET_BOUNDING_BOX);
-        std::string simId;
-        buf >> simId;
-        uint8_t typeId_resp;
-        buf >> typeId_resp;
-        ASSERT(typeId_resp == TYPE_POLYGON);
-        uint8_t npoints;
-        buf >> npoints;
-        ASSERT(npoints == 2);
-        double x1;
-        buf >> x1;
-        double y1;
-        buf >> y1;
-        double x2;
-        buf >> x2;
-        double y2;
-        buf >> y2;
-        ASSERT(buf.eof());
-
-        TraCICoord netbounds1 = TraCICoord(x1, y1);
-        TraCICoord netbounds2 = TraCICoord(x2, y2);
-        EV_DEBUG << "TraCI reports network boundaries (" << x1 << ", " << y1 << ")-(" << x2 << ", " << y2 << ")" << endl;
-        connection->setNetbounds(netbounds1, netbounds2, par("margin"));
-        if (world && ((connection->traci2omnet(netbounds2).x > world->getPgs()->x) || (connection->traci2omnet(netbounds1).y > world->getPgs()->y))) {
-            EV_DEBUG << "WARNING: Playground size (" << world->getPgs()->x << ", " << world->getPgs()->y << ") might be too small for vehicle at network bounds (" << connection->traci2omnet(netbounds2).x << ", " << connection->traci2omnet(netbounds1).y << ")" << endl;
+        // query and set road network boundaries
+        auto networkBoundaries = commandInterface->initNetworkBoundaries(par("margin"));
+        if (world != nullptr && ((connection->traci2omnet(networkBoundaries.second).x > world->getPgs()->x) || (connection->traci2omnet(networkBoundaries.first).y > world->getPgs()->y))) {
+            EV_DEBUG << "WARNING: Playground size (" << world->getPgs()->x << ", " << world->getPgs()->y << ") might be too small for vehicle at network bounds (" << connection->traci2omnet(networkBoundaries.second).x << ", " << connection->traci2omnet(networkBoundaries.first).y << ")" << endl;
         }
     }
 
@@ -375,7 +338,7 @@ void TraCIScenarioManager::init_traci()
         uint8_t variableNumber = 7;
         uint8_t variable1 = VAR_DEPARTED_VEHICLES_IDS;
         uint8_t variable2 = VAR_ARRIVED_VEHICLES_IDS;
-        uint8_t variable3 = VAR_TIME;
+        uint8_t variable3 = commandInterface->getTimeStepCmd();
         uint8_t variable4 = VAR_TELEPORT_STARTING_VEHICLES_IDS;
         uint8_t variable5 = VAR_TELEPORT_ENDING_VEHICLES_IDS;
         uint8_t variable6 = VAR_PARKING_STARTING_VEHICLES_IDS;
@@ -406,7 +369,7 @@ void TraCIScenarioManager::init_traci()
         cModuleType* tlModuleType = cModuleType::get(trafficLightModuleType.c_str());
 
         // query traffic lights via TraCI
-        std::list<std::string> trafficLightIds = getCommandInterface()->getTrafficlightIds();
+        std::list<std::string> trafficLightIds = commandInterface->getTrafficlightIds();
         size_t nrOfTrafficLights = trafficLightIds.size();
         int cnt = 0;
         for (std::list<std::string>::iterator i = trafficLightIds.begin(); i != trafficLightIds.end(); ++i) {
@@ -415,7 +378,7 @@ void TraCIScenarioManager::init_traci()
                 continue; // filter only selected elements
             }
 
-            Coord position = getCommandInterface()->junction(tlId).getPosition();
+            Coord position = commandInterface->junction(tlId).getPosition();
 
             cModule* module = tlModuleType->create(trafficLightModuleName.c_str(), parentmod, nrOfTrafficLights, cnt);
             module->par("externalId") = tlId;
@@ -446,12 +409,12 @@ void TraCIScenarioManager::init_traci()
     if (obstacles) {
         {
             // get list of polygons
-            std::list<std::string> ids = getCommandInterface()->getPolygonIds();
+            std::list<std::string> ids = commandInterface->getPolygonIds();
             for (std::list<std::string>::iterator i = ids.begin(); i != ids.end(); ++i) {
                 std::string id = *i;
-                std::string typeId = getCommandInterface()->polygon(id).getTypeId();
+                std::string typeId = commandInterface->polygon(id).getTypeId();
                 if (!obstacles->isTypeSupported(typeId)) continue;
-                std::list<Coord> coords = getCommandInterface()->polygon(id).getShape();
+                std::list<Coord> coords = commandInterface->polygon(id).getShape();
                 std::vector<Coord> shape;
                 std::copy(coords.begin(), coords.end(), std::back_inserter(shape));
                 obstacles->addFromTypeAndShape(id, typeId, shape);
@@ -979,10 +942,10 @@ void TraCIScenarioManager::processSimSubscription(std::string objectId, TraCIBuf
             parkingVehicleCount -= count;
             drivingVehicleCount += count;
         }
-        else if (variable1_resp == VAR_TIME) {
+        else if (variable1_resp == getCommandInterface()->getTimeStepCmd()) {
             uint8_t varType;
             buf >> varType;
-            ASSERT(varType == TYPE_DOUBLE);
+            ASSERT(varType == getCommandInterface()->getTimeType());
             simtime_t serverTimestep;
             buf >> serverTimestep;
             EV_DEBUG << "TraCI reports current time step as " << serverTimestep << "ms." << endl;


### PR DESCRIPTION
This PR extends the `TraciCommandInterface`, `TraCIBuffer` and some calls to them (in `TraCIScenariomanager`). The makes Veins compatible with Sumo 1.0 (which encodes time as seconds using `double`) and Sumo 0.32 / 0.30 (which encodes time as microseconds using `uint32_t`). Some additional changes in the API were also covered (network boundary format).
The `TraCIBuffer` can now be configured to write `simtime_t` instances either as double or as integer.
The `TraCICommandInterface` now automatically configures itself when `setApiVersion` gets called. All supported API versions and their special types are configured in the `versionConfigs` map. Checking for supported versions is now also done in the `TraCICommandInterface` (as opposed to the `TraCIScenarioManager`). Note that `setApiVersion` has to be called from the scenario manager to allow a separate API check for the `sumo-launchd.py` server.