### PR TITLE
fix Spectrum to work with multiple spectrums

### DIFF
--- a/src/veins/base/toolbox/Spectrum.cc
+++ b/src/veins/base/toolbox/Spectrum.cc
@@ -23,13 +23,9 @@
 using namespace Veins;
 
 Spectrum::Spectrum(Freqs freqs)
+    : frequencies(std::move(freqs))
 {
     // std::cout << "Spectrum constructed" << std::endl;
-
-    frequencies = freqs;
-
-    std::sort(frequencies.begin(), frequencies.end());
-    frequencies.erase(std::unique(frequencies.begin(), frequencies.end()), frequencies.end());
 }
 
 Spectrum::~Spectrum()

--- a/src/veins/base/toolbox/Spectrum.h
+++ b/src/veins/base/toolbox/Spectrum.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <fstream>
 #include <assert.h>
+#include <map>
 
 namespace Veins {
 
@@ -41,7 +42,17 @@ class Spectrum {
 public:
     static SpectrumPtr getInstance(Freqs freqs)
     {
-        static std::shared_ptr<Spectrum> instance(new Spectrum(freqs));
+        static std::map<Freqs, SpectrumPtr> spectrums;
+        // sort and deduplicate frequencies first
+        std::sort(freqs.begin(), freqs.end());
+        freqs.erase(std::unique(freqs.begin(), freqs.end()), freqs.end());
+
+        auto existing_instance = spectrums.find(freqs);
+        if (existing_instance != spectrums.end())
+            return existing_instance->second;
+
+        std::shared_ptr<Spectrum> instance(new Spectrum(freqs));
+        spectrums[freqs] = instance;
         return instance;
     }
     ~Spectrum();


### PR DESCRIPTION
The old implementation used a static singleton implementation for just one spectrum instance. Whatever `Spectrum` instance was constructed first (via `Spectrum::getInstance`) would be used whenever `Spectrum::getInstance` is called, no mater the arguments.

This commit fixes that behavior by using a static **map of `Spectrum`s** instead of just one static spectrum.

In addition, by moving the sorting and deduplication of frequencies into `Spectrum::getInstance`, the result of `Spectrum::getInstance` will now be the same object even for equivalent but not identical frequencies (i.e., having duplicates or different orders).