### PR TITLE
Make Spectrum fully const and refactor code

### DIFF
--- a/src/veins/base/toolbox/Spectrum.cc
+++ b/src/veins/base/toolbox/Spectrum.cc
@@ -32,13 +32,6 @@ Spectrum::Spectrum(Freqs freqs)
     frequencies.erase(std::unique(frequencies.begin(), frequencies.end()), frequencies.end());
 }
 
-Spectrum::~Spectrum()
-{
-    // std::cout << "Spectrum destructed" << std::endl;
-
-    frequencies.clear();
-}
-
 const double& Spectrum::operator[](size_t index) const
 {
     return frequencies.at(index);

--- a/src/veins/base/toolbox/Spectrum.cc
+++ b/src/veins/base/toolbox/Spectrum.cc
@@ -46,9 +46,6 @@ size_t Spectrum::indexOf(double freq) const
     assert(found == true);
 
     return std::distance(frequencies.begin(), it);
-
-    // Linear search
-    // return std::distance(frequencies.begin(), std::find(frequencies.begin(), frequencies.end(), freq));
 }
 
 size_t Spectrum::indexNearLow(double freq) const
@@ -71,7 +68,7 @@ size_t Spectrum::indexNearUp(double freq) const
 
 double Spectrum::freqAt(size_t freqIndex) const
 {
-    return frequencies[freqIndex];
+    return frequencies.at(freqIndex);
 }
 
 size_t Spectrum::getNumFreqs() const
@@ -81,24 +78,20 @@ size_t Spectrum::getNumFreqs() const
 
 void Spectrum::print() const
 {
-    for (uint16_t i = 0; i < frequencies.size(); i++) {
-        std::cout << frequencies[i] << std::endl;
+    for(auto& frequency : frequencies) {
+        std::cout << frequency << std::endl;
     }
 }
 
 void Spectrum::toFile(std::string path) const
 {
-    std::fstream file;
-    file.open(path.c_str(), std::ios::out | std::ios::app);
-
+    std::fstream file(path.c_str(), std::ios::out | std::ios::app);
     if (!file.good()) return;
 
     file << "spectrum:";
-    for (Freqs::iterator it = frequencies.begin(); it != frequencies.end(); ++it) {
+    for (auto it = frequencies.begin(); it != frequencies.end(); ++it) {
         file << *it;
         if (it != frequencies.end() - 1) file << ",";
     }
     file << std::endl;
-
-    file.close();
 }

--- a/src/veins/base/toolbox/Spectrum.cc
+++ b/src/veins/base/toolbox/Spectrum.cc
@@ -51,7 +51,7 @@ size_t Spectrum::indexOf(double freq) const
     // return std::distance(frequencies.begin(), std::find(frequencies.begin(), frequencies.end(), freq));
 }
 
-size_t Spectrum::indexNearLow(double freq)
+size_t Spectrum::indexNearLow(double freq) const
 {
     size_t index = 0;
     for (size_t i = 0; i < frequencies.size(); i++) {
@@ -60,7 +60,7 @@ size_t Spectrum::indexNearLow(double freq)
     return index;
 }
 
-size_t Spectrum::indexNearUp(double freq)
+size_t Spectrum::indexNearUp(double freq) const
 {
     size_t index = frequencies.size() - 1;
     for (size_t i = frequencies.size() - 1; i > 0; i--) {
@@ -79,14 +79,14 @@ size_t Spectrum::getNumFreqs() const
     return frequencies.size();
 }
 
-void Spectrum::print()
+void Spectrum::print() const
 {
     for (uint16_t i = 0; i < frequencies.size(); i++) {
         std::cout << frequencies[i] << std::endl;
     }
 }
 
-void Spectrum::toFile(std::string path)
+void Spectrum::toFile(std::string path) const
 {
     std::fstream file;
     file.open(path.c_str(), std::ios::out | std::ios::app);

--- a/src/veins/base/toolbox/Spectrum.h
+++ b/src/veins/base/toolbox/Spectrum.h
@@ -44,7 +44,7 @@ public:
         static std::shared_ptr<Spectrum> instance(new Spectrum(freqs));
         return instance;
     }
-    ~Spectrum();
+    ~Spectrum() = default;
 
 private:
     Spectrum(Freqs freqs);

--- a/src/veins/base/toolbox/Spectrum.h
+++ b/src/veins/base/toolbox/Spectrum.h
@@ -35,7 +35,7 @@ namespace Veins {
 typedef std::vector<double> Freqs;
 
 class Spectrum;
-typedef std::shared_ptr<Spectrum> SpectrumPtr;
+typedef std::shared_ptr<const Spectrum> SpectrumPtr;
 
 class Spectrum {
 public:

--- a/src/veins/base/toolbox/Spectrum.h
+++ b/src/veins/base/toolbox/Spectrum.h
@@ -57,16 +57,16 @@ public:
     size_t getNumFreqs() const;
 
     size_t indexOf(double freq) const;
-    size_t indexNearLow(double freq);
-    size_t indexNearUp(double freq);
+    size_t indexNearLow(double freq) const;
+    size_t indexNearUp(double freq) const;
 
     double freqAt(size_t freqIndex) const;
 
-    void print();
-    void toFile(std::string path);
+    void print() const;
+    void toFile(std::string path) const;
 
 private:
-    Freqs frequencies;
+    const Freqs frequencies;
 };
 
 } // namespace Veins


### PR DESCRIPTION
Make all function and data members of Spectrum constant. Spectrum objects are not meant to be modified and this way we get bounds cheap checking.

Removed some superfluous code (clear in destructor) and modernized the rest.

This can be used in addition with #91 