### PR TITLE
use right abs function in assertClose

### DIFF
--- a/src/veins/base/utils/asserts.h
+++ b/src/veins/base/utils/asserts.h
@@ -51,7 +51,7 @@ void assertFalse(std::string msg, bool value);
 template <class T>
 void assertClose(std::string msg, T target, T actual)
 {
-    if (fabs(target - actual) > 0.0000001) {
+    if (std::abs(target - actual) > 0.0000001) {
         fail(msg, target, actual);
     }
     else {


### PR DESCRIPTION
Current code throws a warning:

    In file included from veins/modules/application/traci/TraCITestApp.cc:23:
    ./veins/base/utils/asserts.h:54:9: warning: using floating point absolute value function 'fabs' when argument is of integer type [-Wabsolute-value]
        if (fabs(target - actual) > 0.0000001) {
            ^
    veins/modules/application/traci/TraCITestApp.cc:399:13: note: in instantiation of function template specialization 'assertClose<int>' requested here
                assertClose("(TraCICommandInterface::Vehicle::getLaneIndex)", 0, traciVehicle->getLaneIndex());
                ^
    ./veins/base/utils/asserts.h:54:9: note: use function 'std::abs' instead
        if (fabs(target - actual) > 0.0000001) {
            ^~~~
            std::abs

Using the standard C++ `std::abs` fixes the warning.