### PR TITLE
refactor SignalUtils::getMinSINR

### DIFF
--- a/src/veins/base/toolbox/SignalUtils.cc
+++ b/src/veins/base/toolbox/SignalUtils.cc
@@ -22,6 +22,8 @@
 
 #include "veins/base/messages/AirFrame_m.h"
 
+#include <queue>
+
 namespace Veins {
 namespace SignalUtils {
 
@@ -75,6 +77,60 @@ std::vector<SignalChange> calculateChanges(simtime_t_cref start, simtime_t_cref 
 
     return changes;
 }
+
+template<typename T>
+struct greaterByReceptionEnd {
+    bool operator()(const T &lhs, const T &rhs) const
+    {
+        return lhs.getReceptionEnd() > rhs.getReceptionEnd();
+    };
+};
+
+// assumes time-independent noise (but we assume time-independent signals anyway)
+// assumes interferrerFrames are sorted by reception start time
+// assumes all anaglogue models have been applied to all interfererFrames' signals
+Signal getMaxInterference(simtime_t start, simtime_t end, const Signal& referenceSignal, AirFrameVector& interfererFrames)
+{
+    Spectrum spectrum = referenceSignal.getSpectrum();
+    Signal maxInterference(spectrum);
+    Signal currentInterference(spectrum);
+    std::priority_queue <Signal, std::vector<Signal>, greaterByReceptionEnd<Signal> > signalEndings;
+    simtime_t currentTime = 0;
+
+    for(auto& interfererFrame : interfererFrames) {
+        const Signal& signal = interfererFrame->getSignal();
+        // FIXME: currently compares by pointer, fix as soon as some other comparison method for signals becomes available
+        if (&signal == &referenceSignal) continue; // skip the signal we want to compare to
+        if (signal.getReceptionEnd() <= start || signal.getReceptionStart() > end) continue; // skip signals outside our interval of interest
+        ASSERT(signal.getReceptionEnd() > start); // fail on signals ending before start of interval of interest (should be filtered out anyways)
+        ASSERT(signal.getReceptionStart() <= end);  // fail on signal starting aftser the interval of interest
+        ASSERT(signal.getReceptionStart() >= currentTime); // assume frames are sorted by reception start time
+        ASSERT(signal.getSpectrum() == spectrum);
+        // fetch next signal and advance current time to its start
+        signalEndings.push(signal);
+        currentTime = signal.getReceptionStart();
+
+        // abort at end time
+        if(currentTime >= end) break;
+
+        // remove signals ending before the start of the current one
+        while(signalEndings.top().getReceptionEnd() <= currentTime) {
+            currentInterference -= signalEndings.top();
+            signalEndings.pop();
+        }
+
+        // add curent signal to current total interference
+        currentInterference += signal;
+
+        // update maximum observed interference
+        for (uint16_t spectrumIndex = signal.getDataStart(); spectrumIndex < signal.getDataEnd(); spectrumIndex++) {
+            maxInterference[spectrumIndex] = std::max(currentInterference[spectrumIndex], maxInterference[spectrumIndex]);
+        }
+    }
+
+    return maxInterference;
+}
+
 } // namespace
 
 double getGlobalMax(simtime_t start, simtime_t end, const AirFrameVector& airFrames)
@@ -297,56 +353,14 @@ double getMinSINR(simtime_t start, simtime_t end, AirFrame* signalFrame, AirFram
     Signal& signal = signalFrame->getSignal();
     Spectrum spectrum = signal.getSpectrum();
 
-    Signal interference_noise = Signal(spectrum);
-    interference_noise = noise;
+    Signal interference_noise = getMaxInterference(start, end, signal, interfererFrames) + noise;
+    Signal sinr = signal / interference_noise;
 
-    Signal sinr = Signal(spectrum);
-
-    // Method will "filter out" the signalFrame
-    auto changes = calculateChanges(start, end, interfererFrames, signalFrame);
-    std::sort(changes.begin(), changes.end(), compareByTime);
-
-    // Prepare I+N at the beginning
-    auto changesIt = changes.begin();
-    while (changesIt != changes.end()) {
-        if (changesIt->time <= start) {
-            interference_noise += *(changesIt->signal);
-        }
-        else {
-            break;
-        }
-        changesIt++;
-    }
-
-    // Make sure to calculate SINR at the beginning
-    double minSINR = INFINITY;
-
+    double min_sinr = INFINITY;
     for (uint16_t i = signal.getDataStart(); i < signal.getDataEnd(); i++) {
-        double sinr = signal[i] / interference_noise[i];
-        if (sinr < minSINR) minSINR = sinr;
+        min_sinr = std::min(min_sinr, sinr[i]);
     }
-
-    // Calculate all chunks
-    while (changesIt != changes.end()) {
-
-        if (changesIt->type == ChangeType::starting) {
-            interference_noise += *(changesIt->signal);
-        }
-        else if (changesIt->type == ChangeType::ending) {
-            interference_noise -= *(changesIt->signal);
-        }
-
-        auto changesNext = std::next(changesIt);
-        if (changesNext == changes.end() || changesIt->time != changesNext->time) {
-            for (uint16_t i = signal.getDataStart(); i < signal.getDataEnd(); i++) {
-                double sinr = signal[i] / interference_noise[i];
-                if (sinr < minSINR) minSINR = sinr;
-            }
-        }
-        changesIt++;
-    }
-
-    return minSINR;
+    return min_sinr;
 }
 
 } // namespace SignalUtils

--- a/subprojects/veins_catch/src/SignalRepresentation.cc
+++ b/subprojects/veins_catch/src/SignalRepresentation.cc
@@ -1233,10 +1233,10 @@ SCENARIO("SignalUtils Get Min SINR Complex Test Case", "[toolbox]")
         airFrames.push_back(&signalFrame);
 
         const std::vector<std::pair<double, double>> timings = {
-            {5, 10},
             {0, 5},
             {0, 7.5},
             {5, 5},
+            {5, 10},
             {7.5, 5},
             {10, 5},
             {12.5, 7.5},


### PR DESCRIPTION
Remove need to split signals into start and end events (changes).
Only compute maximum interference over whole runtime for every frequency.
Derive SINR once and avoid many unnecessary divisions.

One test had to be adapted to maintain order of interers.

Now we only have to decide if we want to remove the remaining (unused!) functions in `SignalUtils` or adapt them to use `getMaxInterference` from this PR.