### PR TITLE
add handleBroadcast handler to Mac

### DIFF
--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -595,6 +595,14 @@ void Mac1609_4::setCCAThreshold(double ccaThreshold_dBm)
     phy11p->setCCAThreshold(ccaThreshold_dBm);
 }
 
+void Mac1609_4::handleBroadcast(Mac80211Pkt* macPkt, DeciderResult80211* res)
+{
+    statsReceivedBroadcasts++;
+    unique_ptr<WaveShortMessage> wsm(check_and_cast<WaveShortMessage*>(macPkt->decapsulate()));
+    wsm->setControlInfo(new PhyToMacControlInfo(res));
+    sendUp(wsm.release());
+}
+
 void Mac1609_4::handleLowerMsg(cMessage* msg)
 {
     Mac80211Pkt* macPkt = check_and_cast<Mac80211Pkt*>(msg);
@@ -620,10 +628,7 @@ void Mac1609_4::handleLowerMsg(cMessage* msg)
         }
     }
     else if (dest == LAddress::L2BROADCAST()) {
-        statsReceivedBroadcasts++;
-        unique_ptr<WaveShortMessage> wsm(check_and_cast<WaveShortMessage*>(macPkt->decapsulate()));
-        wsm->setControlInfo(new PhyToMacControlInfo(res));
-        sendUp(wsm.release());
+        handleBroadcast(macPkt, res);
     }
     else {
         EV_TRACE << "Packet not for me" << std::endl;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -61,6 +61,8 @@ namespace Veins {
  * @see Decider80211p
  */
 
+class DeciderResult80211;
+
 class Mac1609_4 : public BaseMacLayer, public WaveAppToMac1609_4Interface {
 
 public:
@@ -203,6 +205,9 @@ protected:
 
     /** @brief Handle control messages from lower layer.*/
     virtual void handleLowerControl(cMessage* msg);
+
+    /** @brief Handle received broadcast */
+    virtual void handleBroadcast(Mac80211Pkt* macPkt, DeciderResult80211* res);
 
     /** @brief Set a state for the channel selecting operation.*/
     void setActiveChannel(t_channel state);


### PR DESCRIPTION
This will enable derived projects, e.g., LanRadio to easily extend the Mac1609_4.