### PR TITLE
Fix ObstacleControl::finish overhead.

### DIFF
--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -49,11 +49,7 @@ void ObstacleControl::initialize(int stage)
 
 void ObstacleControl::finish()
 {
-    for (Obstacles::iterator i = obstacles.begin(); i != obstacles.end(); ++i) {
-        for (ObstacleGridRow::iterator j = i->begin(); j != i->end(); ++j) {
-            while (j->begin() != j->end()) erase(*j->begin());
-        }
-    }
+    obstacleOwner.clear();
     obstacles.clear();
 }
 
@@ -142,6 +138,7 @@ void ObstacleControl::addFromTypeAndShape(std::string id, std::string typeId, st
 void ObstacleControl::add(Obstacle obstacle)
 {
     Obstacle* o = new Obstacle(obstacle);
+    obstacleOwner.emplace_back(o);
 
     size_t fromRow = std::max(0, int(o->getBboxP1().x / GRIDCELL_SIZE));
     size_t toRow = std::max(0, int(o->getBboxP2().x / GRIDCELL_SIZE));
@@ -178,7 +175,13 @@ void ObstacleControl::erase(const Obstacle* obstacle)
     }
 
     if (annotations && obstacle->visualRepresentation) annotations->erase(obstacle->visualRepresentation);
-    delete obstacle;
+    for (auto itOwner = obstacleOwner.begin(); itOwner != obstacleOwner.end(); ++itOwner) {
+        // find owning pointer and remove it to deallocate obstacle
+        if (itOwner->get() == obstacle) {
+            obstacleOwner.erase(itOwner);
+            break;
+        }
+    }
 
     cacheEntries.clear();
 }

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <list>
+#include <memory>
 
 #include "veins/veins.h"
 
@@ -99,6 +100,7 @@ protected:
     cXMLElement* obstaclesXml; /**< obstacles to add at startup */
 
     Obstacles obstacles;
+    std::vector< std::unique_ptr<Obstacle> > obstacleOwner;
     AnnotationManager* annotations;
     AnnotationManager::Group* annotationGroup;
     std::map<std::string, double> perCut;


### PR DESCRIPTION
ObstacleControl::finish took a lot of time to clean up on finish (up to minutes for large scenarios with many obstacles). This was due to three nested loops in finish that called erase, which in turn ran the same three nested loops to delete a single obstacle.

This patch simply adds an owning container for each covered obstacle. It contains a unique_ptr as an owner for each obstacle. On finish, the container gets cleaned up, which in turn deletes the Obstacle instances.

ObstacleControl::erase became a bit more complicated because it has to find the owning unique_ptr for the Obstacle to delete. However, ObstacleControl::erase has no longer a caller in the code and
was only left in because it is a public method. (The only previous caller was ObstacleControl::finish).