### PR TITLE
Remove handleMessage() function of PhyLayer80211p

### DIFF
--- a/src/veins/modules/phy/PhyLayer80211p.cc
+++ b/src/veins/modules/phy/PhyLayer80211p.cc
@@ -381,38 +381,6 @@ void PhyLayer80211p::changeListeningFrequency(double freq)
     dec->changeFrequency(freq);
 }
 
-void PhyLayer80211p::handleMessage(cMessage* msg)
-{
-    // self messages
-    if (msg->isSelfMessage()) {
-        handleSelfMessage(msg);
-
-        // MacPkts <- MacToPhyControlInfo
-    }
-    else if (msg->getArrivalGateId() == upperLayerIn) {
-        BasePhyLayer::handleUpperMessage(msg);
-
-        // controlmessages
-    }
-    else if (msg->getArrivalGateId() == upperControlIn) {
-        BasePhyLayer::handleUpperControlMessage(msg);
-
-        // AirFrames
-    }
-    else if (msg->getKind() == AIR_FRAME) {
-        if (dynamic_cast<AirFrame11p*>(msg) == nullptr) {
-            EV_TRACE << "non-AirFrame11p received. Will be discarded!" << std::endl;
-            delete msg;
-            return;
-        }
-        BasePhyLayer::handleAirFrame(static_cast<AirFrame*>(msg));
-    }
-    else {
-        EV << "Unknown message received." << endl;
-        delete msg;
-    }
-}
-
 void PhyLayer80211p::handleSelfMessage(cMessage* msg)
 {
 

--- a/src/veins/modules/phy/PhyLayer80211p.h
+++ b/src/veins/modules/phy/PhyLayer80211p.h
@@ -161,7 +161,6 @@ protected:
 
     void changeListeningFrequency(double freq) override;
 
-    void handleMessage(cMessage* msg) override;
     void handleSelfMessage(cMessage* msg) override;
     int getRadioState() override;
     simtime_t setRadioState(int rs) override;


### PR DESCRIPTION
PhyLayer80211p::handleMessage() function was introduced in commit '15a4d3b432cd91a6cec03d788d294f9a7d966ed4' to ensure that non-AirFrame11p frames are not considered by PhyLayer80211p. This can happen only if a global connection manager is used. However, now that Veins VLC has a connection manager of its own AirFrames of different types will not be mixed, hence there is no need for this check.