### PR TITLE
Unregister from all nics within a vehicle regardless of nic name

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -53,7 +53,6 @@ TraCIScenarioManager::TraCIScenarioManager()
     , connectAndStartTrigger(nullptr)
     , executeOneTimestepTrigger(nullptr)
     , world(nullptr)
-    , cc(nullptr)
 {
 }
 
@@ -263,8 +262,6 @@ void TraCIScenarioManager::initialize(int stage)
     autoShutdownTriggered = false;
 
     world = FindModule<BaseWorldUtility*>::findGlobalModule();
-
-    cc = FindModule<BaseConnectionManager*>::findGlobalModule();
 
     vehicleObstacleControl = FindModule<VehicleObstacleControl*>::findGlobalModule();
 
@@ -542,9 +539,11 @@ void TraCIScenarioManager::deleteManagedModule(std::string nodeId)
 
     emit(traciModuleRemovedSignal, mod);
 
-    cModule* nic = mod->getSubmodule("nic");
-    if (cc && nic) {
-        cc->unregisterNic(nic);
+    auto cas = getSubmodulesOfType<ChannelAccess>(mod, true);
+    for (auto ca : cas) {
+        cModule* nic = ca->getParentModule();
+        auto connectionManager = ChannelAccess::getConnectionManager(nic);
+        connectionManager->unregisterNic(nic);
     }
     if (vehicleObstacleControl) {
         for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -139,7 +139,6 @@ protected:
     cMessage* executeOneTimestepTrigger; /**< self-message scheduled for when to next call executeOneTimestep */
 
     BaseWorldUtility* world;
-    BaseConnectionManager* cc;
     std::map<const TraCIMobility*, const VehicleObstacle*> vehicleObstacles;
     VehicleObstacleControl* vehicleObstacleControl;
 


### PR DESCRIPTION
This allows the TraCIScenarioManager to unregister all nics within a vehicle from the corresponding connection managers they are registered to, regardless of the name of the nic.