### PR TITLE
Modifications to SimpleObstacleShadowing and ObstacleControl

### DIFF
--- a/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
+++ b/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
@@ -32,6 +32,15 @@ SimpleObstacleShadowing::SimpleObstacleShadowing(cComponent* owner, ObstacleCont
 {
     if (useTorus) throw cRuntimeError("SimpleObstacleShadowing does not work on torus-shaped playgrounds");
     annotations = AnnotationManagerAccess().getIfExists();
+
+    // subscribe this Analogue Model to the signal emitted by the Obstacle Control
+    getSimulation()->getSystemModule()->subscribe(ObstacleControl::clearAnalogueModuleCacheSignal, this);
+}
+
+SimpleObstacleShadowing::~SimpleObstacleShadowing()
+{
+    // unsubscribe this Analogue Model from the signal emitted by the Obstacle Control
+    getSimulation()->getSystemModule()->unsubscribe(ObstacleControl::clearAnalogueModuleCacheSignal, this);
 }
 
 void SimpleObstacleShadowing::filterSignal(Signal* signal)
@@ -77,4 +86,9 @@ void SimpleObstacleShadowing::filterSignal(Signal* signal)
     EV_TRACE << "value is: " << factor << endl;
 
     *signal *= factor;
+}
+
+void SimpleObstacleShadowing::receiveSignal(cComponent* source, simsignal_t signalID, bool b, cObject* details)
+{
+    if (signalID == ObstacleControl::clearAnalogueModuleCacheSignal) cacheEntries.clear();
 }

--- a/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
+++ b/src/veins/modules/analogueModel/SimpleObstacleShadowing.cc
@@ -55,7 +55,7 @@ void SimpleObstacleShadowing::filterSignal(Signal* signal)
     }
     else {
         // calculate attenuation for given obstacles
-        std::set<Obstacle const*> potentialObstacles = obstacleControl.getPotentialObstacles(senderPos, receiverPos);
+        std::vector<Obstacle const*> potentialObstacles = obstacleControl.getPotentialObstacles(senderPos, receiverPos);
         for (auto o : potentialObstacles) {
 
             double factorOld = factor;

--- a/src/veins/modules/analogueModel/SimpleObstacleShadowing.h
+++ b/src/veins/modules/analogueModel/SimpleObstacleShadowing.h
@@ -40,7 +40,7 @@ class Signal;
  *
  * @ingroup analogueModels
  */
-class SimpleObstacleShadowing : public AnalogueModel {
+class SimpleObstacleShadowing : public AnalogueModel, public cListener {
 protected:
     struct CacheKey {
         const Coord senderPos;
@@ -87,6 +87,7 @@ public:
      * @param playgroundSize information about the playground the host is moving in
      */
     SimpleObstacleShadowing(cComponent* owner, ObstacleControl& obstacleControl, bool useTorus, const Coord& playgroundSize);
+    ~SimpleObstacleShadowing();
 
     /**
      * @brief Filters a specified Signal by adding an attenuation
@@ -98,6 +99,8 @@ public:
     {
         return true;
     }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, bool b, cObject* details) override;
 };
 
 } // namespace Veins

--- a/src/veins/modules/analogueModel/SimpleObstacleShadowing.h
+++ b/src/veins/modules/analogueModel/SimpleObstacleShadowing.h
@@ -42,6 +42,24 @@ class Signal;
  */
 class SimpleObstacleShadowing : public AnalogueModel {
 protected:
+    struct CacheKey {
+        const Coord senderPos;
+        const Coord receiverPos;
+
+        bool operator<(const CacheKey& o) const
+        {
+            if (senderPos.x < o.senderPos.x) return true;
+            if (senderPos.x > o.senderPos.x) return false;
+            if (senderPos.y < o.senderPos.y) return true;
+            if (senderPos.y > o.senderPos.y) return false;
+            if (receiverPos.x < o.receiverPos.x) return true;
+            if (receiverPos.x > o.receiverPos.x) return false;
+            if (receiverPos.y < o.receiverPos.y) return true;
+            if (receiverPos.y > o.receiverPos.y) return false;
+            return false;
+        }
+    };
+
     /** @brief reference to global ObstacleControl instance */
     ObstacleControl& obstacleControl;
 
@@ -50,6 +68,10 @@ protected:
 
     /** @brief The size of the playground.*/
     const Coord& playgroundSize;
+
+    using CacheEntries = std::map<CacheKey, double>;
+    mutable CacheEntries cacheEntries;
+    AnnotationManager* annotations;
 
 public:
     /**

--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <map>
 #include <set>
+#include <algorithm>
 
 #include "veins/modules/obstacle/ObstacleControl.h"
 
@@ -182,7 +183,7 @@ void ObstacleControl::erase(const Obstacle* obstacle)
     }
 }
 
-std::set<Obstacle const*> ObstacleControl::getPotentialObstacles(const Coord& senderPos, const Coord& receiverPos) const
+std::vector<Obstacle const*> ObstacleControl::getPotentialObstacles(const Coord& senderPos, const Coord& receiverPos) const
 {
     Enter_Method_Silent();
 
@@ -195,7 +196,7 @@ std::set<Obstacle const*> ObstacleControl::getPotentialObstacles(const Coord& se
     size_t fromCol = std::max(0, int(bboxP1.y / GRIDCELL_SIZE));
     size_t toCol = std::max(0, int(bboxP2.y / GRIDCELL_SIZE));
 
-    std::set<Obstacle const*> processedObstacles;
+    std::vector<Obstacle const*> processedObstacles;
     for (size_t col = fromCol; col <= toCol; ++col) {
         if (col >= obstacles.size()) break;
         for (size_t row = fromRow; row <= toRow; ++row) {
@@ -205,8 +206,8 @@ std::set<Obstacle const*> ObstacleControl::getPotentialObstacles(const Coord& se
 
                 Obstacle* o = *k;
 
-                if (processedObstacles.find(o) != processedObstacles.end()) continue;
-                processedObstacles.insert(o);
+                if (std::find(processedObstacles.begin(), processedObstacles.end(), o) != processedObstacles.end()) continue;
+                processedObstacles.push_back(o);
             }
         }
     }

--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -30,6 +30,8 @@ using Veins::ObstacleControl;
 
 Define_Module(Veins::ObstacleControl);
 
+const simsignal_t ObstacleControl::clearAnalogueModuleCacheSignal = registerSignal("org.car2x.veins.modules.obstacle.clearAnalogueModuleCache");
+
 ObstacleControl::~ObstacleControl()
 {
 }
@@ -155,6 +157,9 @@ void ObstacleControl::add(Obstacle obstacle)
 
     // visualize using AnnotationManager
     if (annotations) o->visualRepresentation = annotations->drawPolygon(o->getShape(), "red", annotationGroup);
+
+    // invalidate cache when obstacle is deleted at runtime
+    emit(clearAnalogueModuleCacheSignal, true);
 }
 
 void ObstacleControl::erase(const Obstacle* obstacle)
@@ -181,6 +186,9 @@ void ObstacleControl::erase(const Obstacle* obstacle)
             break;
         }
     }
+
+    // invalidate cache when obstacle is deleted at runtime
+    emit(clearAnalogueModuleCacheSignal, true);
 }
 
 std::vector<Obstacle const*> ObstacleControl::getPotentialObstacles(const Coord& senderPos, const Coord& receiverPos) const

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -40,6 +40,8 @@ namespace Veins {
  */
 class ObstacleControl : public cSimpleModule {
 public:
+    static const simsignal_t clearAnalogueModuleCacheSignal;
+
     ~ObstacleControl() override;
     void initialize(int stage) override;
     int numInitStages() const override
@@ -67,7 +69,7 @@ public:
 
 protected:
     enum {
-        GRIDCELL_SIZE = 1024,
+        GRIDCELL_SIZE = 1024
     };
 
     using ObstacleGridCell = std::list<Obstacle*>;

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -57,45 +57,22 @@ public:
     bool isTypeSupported(std::string type);
     double getAttenuationPerCut(std::string type);
     double getAttenuationPerMeter(std::string type);
+    bool isAnyObstacleDefined();
 
     /**
      * calculate additional attenuation by obstacles, return signal strength
      */
-    double calculateAttenuation(const Coord& senderPos, const Coord& receiverPos) const;
+    double calculateAttenuation(const Coord& senderPos, const Coord& receiverPos, const Obstacle& o) const;
+    std::set<Obstacle const*> getPotentialObstacles(const Coord& senderPos, const Coord& receiverPos) const;
 
 protected:
-    struct CacheKey {
-        const Coord senderPos;
-        const Coord receiverPos;
-
-        CacheKey(const Coord& senderPos, const Coord& receiverPos)
-            : senderPos(senderPos)
-            , receiverPos(receiverPos)
-        {
-        }
-
-        bool operator<(const CacheKey& o) const
-        {
-            if (senderPos.x < o.senderPos.x) return true;
-            if (senderPos.x > o.senderPos.x) return false;
-            if (senderPos.y < o.senderPos.y) return true;
-            if (senderPos.y > o.senderPos.y) return false;
-            if (receiverPos.x < o.receiverPos.x) return true;
-            if (receiverPos.x > o.receiverPos.x) return false;
-            if (receiverPos.y < o.receiverPos.y) return true;
-            if (receiverPos.y > o.receiverPos.y) return false;
-            return false;
-        }
-    };
-
     enum {
-        GRIDCELL_SIZE = 1024
+        GRIDCELL_SIZE = 1024,
     };
 
     using ObstacleGridCell = std::list<Obstacle*>;
     using ObstacleGridRow = std::vector<ObstacleGridCell>;
     using Obstacles = std::vector<ObstacleGridRow>;
-    typedef std::map<CacheKey, double> CacheEntries;
 
     cXMLElement* obstaclesXml; /**< obstacles to add at startup */
 
@@ -105,7 +82,6 @@ protected:
     AnnotationManager::Group* annotationGroup;
     std::map<std::string, double> perCut;
     std::map<std::string, double> perMeter;
-    mutable CacheEntries cacheEntries;
 };
 
 class ObstacleControlAccess {

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -63,7 +63,7 @@ public:
      * calculate additional attenuation by obstacles, return signal strength
      */
     double calculateAttenuation(const Coord& senderPos, const Coord& receiverPos, const Obstacle& o) const;
-    std::set<Obstacle const*> getPotentialObstacles(const Coord& senderPos, const Coord& receiverPos) const;
+    std::vector<Obstacle const*> getPotentialObstacles(const Coord& senderPos, const Coord& receiverPos) const;
 
 protected:
     enum {

--- a/src/veins/modules/obstacle/ObstacleControl.ned
+++ b/src/veins/modules/obstacle/ObstacleControl.ned
@@ -27,8 +27,9 @@ simple ObstacleControl
 {
     parameters:
         @class(Veins::ObstacleControl);
-        xml obstacles = default(xml("<obstacles/>")); // list of obstacle types and obstacles to load
         @display("i=misc/town");
         @labels(node);
+        @signal[org.car2x.veins.modules.obstacle.clearAnalogueModuleCache](type=bool);
+        xml obstacles = default(xml("<obstacles/>")); // list of obstacle types and obstacles to load
 }
 


### PR DESCRIPTION
This commit separates some of the tasks performed by `ObstacleControl::calculateAttenuation()` into multiple functions.

The original `ObstacleControl::calculateAttenuation()` performed the following tasks:
1) Sanity checks: check if there are any obstacles or obstacle types; if yes calculate the attenuation factor.
2) Use cached attenuation factor values from previous calculations.
3) Calculate the attenuation factor if there is no entry satisfying point 2.

Modifications:
1) becomes a function of its own: `ObstacleControl::isAnyObstacleDefined()` and is called by `SimpleObstacleShadowing::fileterSignal()`
2) moves from `ObstacleControl::calculateAttenuation()` to `SimpleObstacleShadowing::fileterSignal()`
3) is separated into `ObstacleControl::calculateAttenuation()` and `ObstacleControl::calculateAttenuation()` and `ObstacleControl::getPotentialObstacles`

With these modifications it becomes easier for other communication technologies to have their implementations for obstacle shadowing.