### PR TITLE
Fix simple pathloss tests

### DIFF
--- a/subprojects/veins_catch/src/SimplePathlossModel.cc
+++ b/subprojects/veins_catch/src/SimplePathlossModel.cc
@@ -31,44 +31,44 @@ SCENARIO("SimplePathlossModel with alpha = 2", "[analogueModel]")
     GIVEN("A signal sent from (0, 0) with powerlevel 1")
     {
         Signal s(spec);
-        for (size_t i = 0; i < freqs.size(); ++i) s.at(i) = 1;
-        const AntennaPosition senderPos = createDummyAntennaPosition(Coord(0, 0, 2));
+        s = 1;
+        s.setSenderPoa({createDummyAntennaPosition(Coord(0, 0, 2)), {}, nullptr});
         WHEN("the receiver is at (2, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(2, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(2, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 4.0874e-6")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(4.0874e-6).epsilon(0.001));
             }
         }
 
         WHEN("the receiver is at (5, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(5, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(5, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 6.539e-7")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(6.539e-7).epsilon(0.001));
             }
         }
 
         WHEN("the receiver is at (10, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(10, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(10, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 1.634e-7")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(1.634e-7).epsilon(0.001));
             }
         }
 
         WHEN("the receiver is at (100, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(100, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(100, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 1.634e-9")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(1.634e-9).epsilon(0.001));
             }
         }
@@ -87,44 +87,44 @@ SCENARIO("SimplePathlossModel with alpha = 2.2", "[analogueModel]")
     GIVEN("A signal sent from (0, 0) with powerlevel 1")
     {
         Signal s(spec);
-        for (size_t i = 0; i < freqs.size(); ++i) s.at(i) = 1;
-        const AntennaPosition senderPos = createDummyAntennaPosition(Coord(0, 0, 2));
+        s = 1;
+        s.setSenderPoa({createDummyAntennaPosition(Coord(0, 0, 2)), {}, nullptr});
         WHEN("the receiver is at (2, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(2, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(2, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 3.5583e-6")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(3.5583e-6).epsilon(0.001));
             }
         }
 
         WHEN("the receiver is at (5, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(5, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(5, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 4.7400e-7")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(4.7400e-7).epsilon(0.001));
             }
         }
 
         WHEN("the receiver is at (10, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(10, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(10, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 1.0316e-7")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(1.0316e-7).epsilon(0.001));
             }
         }
 
         WHEN("the receiver is at (100, 0)")
         {
-            const AntennaPosition receiverPos = createDummyAntennaPosition(Coord(100, 0, 2));
+            s.setReceiverPoa({createDummyAntennaPosition(Coord(100, 0, 2)), {}, nullptr});
             THEN("SimplePathlossModel drops power from 1 to 6.5090e-10")
             {
-                spm.filterSignal(&s, senderPos, receiverPos);
+                spm.filterSignal(&s);
                 REQUIRE(s.at(1) == Approx(6.5090e-10).epsilon(0.001));
             }
         }


### PR DESCRIPTION
The tests were broken by an API change introduced by #117. This adapts the tests to the new
API without any semantic changes.