### PR TITLE
Code fomatting tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,10 @@ doxy:
 doxyshow: doxy
 	xdg-open doc/doxy/index.html
 
+formatting: uncrustify
+
+clang-format:
+	find . -name "*.cc" -o -name "*.h" | xargs clang-format -style=file -i
+
+uncrustify: clang-format
+	find . -name "*.cc" -o -name "*.h" | xargs uncrustify --replace --no-backup -c .uncrustify.cfg

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all makefiles clean cleanall doxy formatting clang-format uncrustify
+.PHONY: all makefiles clean cleanall doxy formatting
 
 # if out/config.py exists, we can also create command line scripts for running simulations
 ADDL_TARGETS =
@@ -76,10 +76,6 @@ doxy:
 doxyshow: doxy
 	xdg-open doc/doxy/index.html
 
-formatting: clang-format uncrustify
-
-clang-format:
-	find . -name "*.cc" -o -name "*.h" | xargs clang-format -style=file -i
-
-uncrustify:
-	find . -name "*.cc" -o -name "*.h" | xargs uncrustify --replace --no-backup -c .uncrustify.cfg
+formatting:
+	./format-code.sh src
+	./format-code.sh subprojects

--- a/Makefile
+++ b/Makefile
@@ -76,10 +76,10 @@ doxy:
 doxyshow: doxy
 	xdg-open doc/doxy/index.html
 
-formatting: uncrustify
+formatting: clang-format uncrustify
 
 clang-format:
 	find . -name "*.cc" -o -name "*.h" | xargs clang-format -style=file -i
 
-uncrustify: clang-format
+uncrustify:
 	find . -name "*.cc" -o -name "*.h" | xargs uncrustify --replace --no-backup -c .uncrustify.cfg

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all makefiles clean cleanall doxy
+.PHONY: all makefiles clean cleanall doxy formatting clang-format uncrustify
 
 # if out/config.py exists, we can also create command line scripts for running simulations
 ADDL_TARGETS =

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,4 +1,35 @@
 #!/bin/bash
 
+MINIMUM_VERSION_CF="6.0.0"
+MINIMUM_VERSION_UF="0.68"
+
+# check (minimum) versions of clang-format and uncrustify
+
+CF=$(clang-format --version)
+if [[ ($? -eq 0) && ($CF =~ ^clang-format) ]]; then
+    VERSION_CF=$(echo $CF | sed -n 's/clang-format version \([0-9\.]\+\).*$/\1/p')
+#    dpkg --compare-versions "$MINIMUM_VERSION_CF" "lt" "$VERSION_CF" # only works on debian-based systems
+    printf "%s\n%s" "$MINIMUM_VERSION_CF" "$VERSION_CF" | sort -C -V
+    if [[ $? -eq 1 ]]; then
+        exit "Your version of clang-format is too old!"
+    fi
+else
+    exit "Cannot find clang-format or version check does not work!"
+fi
+
+UF=$(uncrustify --version)
+if [[ ($? -eq 0) && ($UF =~ ^Uncrustify-) ]]; then
+    VERSION_UF=$(echo $UF | sed -n 's/Uncrustify-\([0-9\.]\+\).*$/\1/p')
+#    dpkg --compare-versions "$MINIMUM_VERSION_UF" "lt" "$VERSION_UF" # only works on debian-based systems
+    printf "%s\n%s" "$MINIMUM_VERSION_UF" "$VERSION_UF" | sort -C -V
+    if [[ $? -eq 1 ]]; then
+        exit "Your version of uncrustify is too old!"
+    fi
+else
+    exit "Cannot find clang-format or version check does not work!"
+fi
+
+# actually format the code
+
 find "$@" -name "*.cc" -o -name "*.h" | xargs clang-format -style=file -i
 find "$@" -name "*.cc" -o -name "*.h" | xargs uncrustify --replace --no-backup -c .uncrustify.cfg

--- a/format-code.sh
+++ b/format-code.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+find "$@" -name "*.cc" -o -name "*.h" | xargs clang-format -style=file -i
+find "$@" -name "*.cc" -o -name "*.h" | xargs uncrustify --replace --no-backup -c .uncrustify.cfg


### PR DESCRIPTION
This adds targets for code formatting to the makefile.

Formatting the code is as optional as generating the documentation (therefore, there targets). However, since the repository contains config files for clang-format and uncrustify and the code base should be kept consistent (to the upstream repository) in terms of the formatting, especially for further pull requests, I believe it is useful to have these targets.