### PR TITLE
WIP: Update generated output for documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ doxy:
 	doxygen doxy.cfg
 
 doxyshow: doxy
-	xdg-open doc/doxy/index.html
+	xdg-open doc/doxy/html/index.html
 
 formatting:
 	./format-code.sh src

--- a/doxy.cfg
+++ b/doxy.cfg
@@ -1649,7 +1649,7 @@ MAKEINDEX_CMD_NAME     = makeindex
 # The default value is: NO.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-COMPACT_LATEX          = NO
+COMPACT_LATEX          = YES
 
 # The PAPER_TYPE tag can be used to set the paper type that is used by the
 # printer.

--- a/doxy.cfg
+++ b/doxy.cfg
@@ -1615,7 +1615,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = NO
+GENERATE_LATEX         = YES
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/doxy.cfg
+++ b/doxy.cfg
@@ -1071,7 +1071,7 @@ GENERATE_HTML          = YES
 # The default directory is: html.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_OUTPUT            = .
+HTML_OUTPUT            = html
 
 # The HTML_FILE_EXTENSION tag can be used to specify the file extension for each
 # generated HTML page (for example: .htm, .php, .asp).


### PR DESCRIPTION
This PR updates the generated documentation. The hmtl output is moved to a dedicated directory, which allows latex output to be generated (i.e., in a dedicated directory as well). Thus, we can start writing actual documentation, which can be compiled to a pdf as well.