### PR TITLE
Add path to uncrustify config within format script

### DIFF
--- a/format-code.sh
+++ b/format-code.sh
@@ -62,4 +62,4 @@ else
 fi
 
 # actually format the code
-find "$@" \( -name "*.cc" -or -name "*.h" \) -exec uncrustify -q --replace --no-backup -c $(dirname $0)/.uncrustify.cfg "{}" \;
+find "$@" \( -name "*.cc" -or -name "*.h" \) -exec uncrustify -q --replace --no-backup -c "$(dirname "$0")"/.uncrustify.cfg "{}" \;

--- a/format-code.sh
+++ b/format-code.sh
@@ -62,4 +62,4 @@ else
 fi
 
 # actually format the code
-find "$@" \( -name "*.cc" -or -name "*.h" \) -exec uncrustify -q --replace --no-backup -c $(dirname $0 | xargs readlink -f)/.uncrustify.cfg "{}" \;
+find "$@" \( -name "*.cc" -or -name "*.h" \) -exec uncrustify -q --replace --no-backup -c $(dirname $0)/.uncrustify.cfg "{}" \;

--- a/format-code.sh
+++ b/format-code.sh
@@ -62,4 +62,4 @@ else
 fi
 
 # actually format the code
-find "$@" \( -name "*.cc" -or -name "*.h" \) -exec uncrustify -q --replace --no-backup -c .uncrustify.cfg "{}" \;
+find "$@" \( -name "*.cc" -or -name "*.h" \) -exec uncrustify -q --replace --no-backup -c $(dirname $0 | xargs readlink -f)/.uncrustify.cfg "{}" \;


### PR DESCRIPTION
This allows to call the script from an arbitrary directory within veins to format code using the uncrustify config from the root directory (e.g., the subprojects).