### PR TITLE
Add simulation signal management utilities.

### DIFF
--- a/doc/manual/simsignal_management.md
+++ b/doc/manual/simsignal_management.md
@@ -1,0 +1,117 @@
+# Simulation Signal Management {#simsignal_management}
+
+[TOC]
+
+OMNeT++ provides the *Simulation Signals* (or just *Signals* for short) as a publish-subscribe mechanism in the simulation.
+Assume some signal emitting Module like this:
+
+```{.cpp}
+// module emitting some signal whenever it receives a message (contrived example)
+class SignalEmitter: public cModule {
+public:
+    static const simsignal_t counterSignal;
+    static const simsignal_t nameSignal;
+protected:
+    long messageCounter = 0;
+    void handleMessage(cMessage *msg) {
+        emit(counterSignal, messageCounter);
+        messageCounter++;
+        emit(nameSignal, msg->str());
+        // ...
+    }
+};
+
+const simsignal_t SignalEmitter::counterSignal = registerSignal("messageCounter");
+const simsignal_t SignalEmitter::nameSignal = registerSignal("messageName");
+```
+
+## Using plain OMNeT++ signals
+While signals are easy to configure and emit, reacting to them involves a lot of boilerplate code:
+
+```{.cpp}
+// module reacting to signals in plain OMNeT++ fashion, has to inherit from cListener or implement cIListener
+class WithoutSignalCallbacks: public cModule, public cListener {
+protected:
+    void initialize() override {
+        // subscribe to the signal with itself as handler
+        subscribe(SignalEmitter::counterSignal, this);
+        subscribe(SignalEmitter::nameSignal, this);
+    }
+public:
+    // signal handler for all signals with a long parameter
+    void receiveSignal(cComponent* source, simsignal_t signalID, long l, cObject* details) override {
+        // identify signal to handle
+        if (signalID == SignalEmitter::counterSignal) {
+            // react to signal
+            std::cerr << "Module " << source->getFullName() << " received message nr " << l << std::endl;
+        }
+    }
+    // signal handler for all signals with a string parameter
+    void receiveSignal(cComponent* source, simsignal_t signalID, const char* s, cObject* details) override {
+        // identify signal to handle
+        if (signalID == SignalEmitter::nameSignal) {
+            // react to signal
+            std::cerr << "Module " << source->getFullName() << " received message with content " << c << std::endl;
+        }
+    }
+};
+```
+## SignalManager
+With the [SignalManager], all signal handling can be encapsulated and configuration will stay in one place:
+
+```{.cpp}
+// module reacting to signals using the SignalManager
+class WithSignalManager: public cModule {
+protected:
+    Veins::SignalManager signalManager(this);
+    void initialize() override {
+        // reaction to the signal (note how unused parameters are omitted from the lambda function signature).
+        auto nameSignalCallback = [this](cComponent *source, const char* c) {
+            std::cerr << "Module " << source->getFullName() << " received message with content " << c << std::endl;
+        };
+        auto counterSignalCallback = [this](cComponent* source, simsignal_t signalID, long l) {
+            std::cerr << "Module " << source->getFullName() << " received message nr " << l << " via signal " << signalID << std::endl;
+        };
+        // register callbacks with the signal manager, which takes care to perform the actual subscription
+        signalManager.subscribeCallback(getSystemModule(), SignalEmitter::nameSignal, nameSignalCallback);
+        signalManager.subscribeCallback(getSystemModule(), SignalEmitter::counterSignal, counterSignalCallback);
+    }
+};
+```
+
+## SignalCallback
+Alternatively, we could omit the manager part and make create individual [SignalCallback] objects for each registered callback:
+```{.cpp}
+// module reacting to signals using the SignalCallback instances
+class WithSignalCallbacks: public cModule {
+protected:
+    Veins::SignalCallback counterCallback;
+    Veins::SignalCallback nameCallback;
+    void initialize() override {
+        // reaction to the signal (note how unused parameters are omitted from the lambda function signature).
+        auto nameSignalCallback = [this](cComponent *source, const char* c) {
+            std::cerr << "Module " << source->getFullName() << " received message with content " << c << std::endl;
+        };
+        auto counterSignalCallback = [this](cComponent* source, simsignal_t signalID, long l) {
+            std::cerr << "Module " << source->getFullName() << " received message nr " << l << " via signal " << signalID << std::endl;
+        };
+        // register callback objects, which takes care to perform the actual subscription
+        counterCallback = Veins::SignalCallback::make(getSystemModule(), SignalEmitter::counterSignal, counterSignalCallback);
+        nameCallback = Veins::SignalCallback::make(getSystemModule(), SignalEmitter::nameSignal, nameCallback);
+    }
+};
+```
+
+This allows a closer control over the lifetime of each individual [SignalCallback] instance.
+
+## Common Features
+
+With both [SignalManager] and [SignalCallback], there is no need to implement the cIListener yourself.
+The lifetime is managed automatically and the Code is more self-explanatory and kept in one place.
+In addtion to Lambdas, other forms of callbacks can be used, too, such as free functions and functors.
+
+As shown in the examples, the callbacks can also implement just a subset of the cIListener::receiveSignal signature.
+Valid subsets can be seen by checking the implemented overloads of the @ref Veins::SignalCallbackManagement::invokeCallback template.
+
+[SignalManager]: @ref Veins::SignalManager
+[SignalCallback]: @ref Veins::SignalCallback

--- a/src/veins/modules/utility/CallableInfo.h
+++ b/src/veins/modules/utility/CallableInfo.h
@@ -1,0 +1,67 @@
+//
+// Copyright (C) 2019-2019 Dominik S. Buse <buse@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+/*
+ * Compile-Time introspection into callables (function pointers, lambdas, functors, etc.)
+ *
+ * With this helper, one can identify the return type and individual arguments of any callable.
+ * This allows to convert them info regular std::function types, even in the presence of templated arguments.
+ */
+namespace CallableInfo
+{
+template<class Ret, class Cls, class ... Args>
+struct trait
+{
+    static constexpr size_t arity = sizeof...(Args);
+    using return_type = Ret;
+    using function_equivalent = std::function<Ret(Args...)>;
+
+    template<size_t i>
+    struct arg
+    {
+        using type = typename std::tuple_element<i, std::tuple<Args...>>::type;
+    };
+};
+
+// convenience call for lambdas
+template<class Lambda>
+struct type
+    : type<decltype(&Lambda::operator())>
+{};
+
+// for normal functions / function pointer
+template<class Ret, class ... Args>
+struct type<Ret (*)(Args...)>: trait<Ret, Ret (*)(Args...), Args...>
+{};
+
+// for normal (const) lambdas
+template<class Ret, class Cls, class ... Args>
+struct type<Ret (Cls::*)(Args...) const>: trait<Ret, Cls, Args...>
+{};
+
+// for mutable lambdas
+template<class Ret, class Cls, class ... Args>
+struct type<Ret (Cls::*)(Args...)>: trait<Ret, Cls, Args...>
+{};
+}; // namespace CallableInfo

--- a/src/veins/modules/utility/SignalManager.h
+++ b/src/veins/modules/utility/SignalManager.h
@@ -1,0 +1,181 @@
+//
+// Copyright (C) 2019-2019 Dominik S. Buse <buse@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+#pragma once
+
+#include "veins/veins.h"
+
+#include <functional>
+#include <memory>
+#include <typeinfo>
+
+#include "veins/modules/utility/CallableInfo.h"
+
+
+namespace Veins {
+
+namespace SignalCallbackManagement {
+
+// Generic case: error
+template <typename Payload, typename Callback>
+void invokeCallback(Callback callback, cComponent* source, simsignal_t signalID, Payload p, cObject* details)
+{
+    std::string msg = std::string("Invalid signal subscription for callback with payload type: ") + typeid(Payload).name();
+    throw cRuntimeError(msg.c_str());
+}
+
+// Specific cases (payload matches callback) -> actually invoke callback
+
+// No arguments at all
+template <typename Payload>
+void invokeCallback(std::function<void(void)> callback, cComponent* source, simsignal_t signalID, Payload p, cObject* details)
+{
+    callback();
+}
+
+// Only payload
+template <typename Payload>
+void invokeCallback(std::function<void(Payload p)> callback, cComponent* source, simsignal_t signalID, Payload p, cObject* details)
+{
+    callback(p);
+}
+
+// source and payload
+template <typename Payload>
+void invokeCallback(std::function<void(cComponent*, Payload p)> callback, cComponent* source, simsignal_t signalID, Payload p, cObject* details)
+{
+    callback(source, p);
+}
+
+// source, signalID and payload
+template <typename Payload>
+void invokeCallback(std::function<void(cComponent*, simsignal_t, Payload p)> callback, cComponent* source, simsignal_t signalID, Payload p, cObject* details)
+{
+    callback(source, signalID, p);
+}
+
+// full information (source, signalId, payload and details)
+template <typename Payload>
+void invokeCallback(std::function<void(cComponent*, simsignal_t, Payload p, cObject*)> callback, cComponent* source, simsignal_t signalID, Payload p, cObject* details)
+{
+    callback(source, signalID, p, details);
+}
+
+template <typename Payload, typename Callback>
+class CallbackListener : public cListener {
+public:
+    CallbackListener(Callback callback, cModule* receptor, simsignal_t signal)
+        : callback(callback)
+        , receptor(receptor)
+        , signal(signal)
+    {
+        receptor->subscribe(signal, this);
+    }
+
+    ~CallbackListener()
+    {
+        receptor->unsubscribe(signal, this);
+    }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, bool b, cObject* details) override
+    {
+        invokeCallback<bool>(callback, source, signalID, b, details);
+    }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, long l, cObject* details) override
+    {
+        invokeCallback<long>(callback, source, signalID, l, details);
+    }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, unsigned long l, cObject* details) override
+    {
+        invokeCallback<unsigned long>(callback, source, signalID, l, details);
+    }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, double d, cObject* details) override
+    {
+        invokeCallback<double>(callback, source, signalID, d, details);
+    }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, const SimTime& t, cObject* details) override
+    {
+        invokeCallback<const SimTime&>(callback, source, signalID, t, details);
+    }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, const char* c, cObject* details) override
+    {
+        invokeCallback<const char*>(callback, source, signalID, c, details);
+    }
+
+    void receiveSignal(cComponent* source, simsignal_t signalID, cObject* c, cObject* details) override
+    {
+        invokeCallback<cObject*>(callback, source, signalID, c, details);
+    }
+private:
+    const Callback callback;
+    cModule* const receptor;
+    const simsignal_t signal;
+};
+
+} // namespace SignalCallbackManagement
+
+/*
+ * Handle for a callback subscribed to a signal.
+ */
+class SignalCallback {
+public:
+    template<typename Payload, typename Func>
+    static SignalCallback make(cModule* receptor, simsignal_t signal, const Func callback)
+    {
+        // Note: we have to covert to the target function layout here to allow passing lambdas as callback
+        // (lambdas can only be *converted* to functions, but template deduction needs exactly matching types).
+        using CallbackType = typename CallableInfo::type<Func>::function_equivalent;
+        using CallbackListener = SignalCallbackManagement::CallbackListener<Payload, CallbackType>;
+
+        const CallbackType converted = callback;
+        return SignalCallback(make_unique<CallbackListener>(converted, receptor, signal));
+    }
+private:
+    SignalCallback(std::unique_ptr<cIListener> listener)
+        : listener(std::move(listener))
+    {}
+    std::unique_ptr<cIListener> listener;
+};
+
+/*
+ * Semantic encapsulation for OMNeT++ simulation signals usinng callbacks.
+ *
+ * TODO: Extend documentation.
+ */
+class VEINS_API SignalManager {
+public:
+    /*
+     * Create a subscription to signal that triggers callback.
+     */
+    template <typename Payload, typename Func>
+    void subscribeCallback(cModule* receptor, omnetpp::simsignal_t signal, const Func callback)
+    {
+        auto signalCallback = SignalCallback::make<Payload, Func>(receptor, signal, callback);
+        storedCallbacks.push_back(std::move(signalCallback));
+    }
+private:
+    std::vector<SignalCallback> storedCallbacks;
+};
+
+} // namespace Veins

--- a/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_bool.test
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_bool.test
@@ -1,0 +1,84 @@
+%description
+Ensure CallbackListeners are called.
+
+%file: test.ned
+
+simple Module {
+    @signal[mySignal](type=bool);
+}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/SignalManager.h"
+
+namespace @TESTNAME@ {
+
+using payloadType = bool;
+
+void staticEmptyCallback()
+{
+    EV << "Static callback with empty arguments\n";
+}
+
+void staticPayloadOnlyCallback(payloadType p)
+{
+    EV << "Static payload-only callback\n";
+}
+
+void staticFullCallback(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+{
+    EV << "Static callback with full arguments\n";
+}
+
+struct functorCallback {
+    void operator()(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+    {
+        EV << "Functor callback with full arguments\n";
+    }
+};
+
+class Module : public cSimpleModule {
+public:
+    static const simsignal_t mySignal;
+    Module()
+        : cSimpleModule() {};
+    void initialize(int stage) override;
+protected:
+    Veins::SignalManager signalManager;
+};
+
+const simsignal_t Module::mySignal = registerSignal("mySignal");
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto lambdaCallback = [this](cComponent* source, simsignal_t signal, payloadType p, cObject* details) {
+        EV << "Lambda callback with full arguments\n";
+    };
+    // setup all callbacks
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, lambdaCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticEmptyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticPayloadOnlyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticFullCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, functorCallback());
+
+    // emit message to all callbacks
+    emit(Module::mySignal, true);
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+Lambda callback with full arguments
+Static callback with empty arguments
+Static payload-only callback
+Static callback with full arguments
+Functor callback with full arguments

--- a/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_custom.test
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_custom.test
@@ -1,0 +1,91 @@
+%description
+Ensure CallbackListeners are called.
+
+%file: test.ned
+
+simple Module {
+    @signal[mySignal](type=CustomPayload);
+}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/SignalManager.h"
+
+namespace @TESTNAME@ {
+
+class CustomPayload: public cObject {
+
+};
+
+Register_Class(CustomPayload);
+
+using payloadType = cObject*;
+
+void staticEmptyCallback()
+{
+    EV << "Static callback with empty arguments\n";
+}
+
+void staticPayloadOnlyCallback(payloadType p)
+{
+    EV << "Static payload-only callback\n";
+}
+
+void staticFullCallback(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+{
+    EV << "Static callback with full arguments\n";
+}
+
+struct functorCallback {
+    void operator()(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+    {
+        EV << "Functor callback with full arguments\n";
+    }
+};
+
+class Module : public cSimpleModule {
+public:
+    static const simsignal_t mySignal;
+    Module()
+        : cSimpleModule() {};
+    void initialize(int stage) override;
+protected:
+    Veins::SignalManager signalManager;
+    std::unique_ptr<CustomPayload> customPayload = Veins::make_unique<CustomPayload>();
+};
+
+const simsignal_t Module::mySignal = registerSignal("mySignal");
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto lambdaCallback = [this](cComponent* source, simsignal_t signal, payloadType p, cObject* details) {
+        EV << "Lambda callback with full arguments\n";
+    };
+    // setup all callbacks
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, lambdaCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticEmptyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticPayloadOnlyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticFullCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, functorCallback());
+
+    // emit message to all callbacks
+    emit(Module::mySignal, customPayload.get());
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+Lambda callback with full arguments
+Static callback with empty arguments
+Static payload-only callback
+Static callback with full arguments
+Functor callback with full arguments

--- a/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_double.test
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_double.test
@@ -1,0 +1,84 @@
+%description
+Ensure CallbackListeners are called.
+
+%file: test.ned
+
+simple Module {
+    @signal[mySignal](type=double);
+}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/SignalManager.h"
+
+namespace @TESTNAME@ {
+
+using payloadType = double;
+
+void staticEmptyCallback()
+{
+    EV << "Static callback with empty arguments\n";
+}
+
+void staticPayloadOnlyCallback(payloadType p)
+{
+    EV << "Static payload-only callback\n";
+}
+
+void staticFullCallback(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+{
+    EV << "Static callback with full arguments\n";
+}
+
+struct functorCallback {
+    void operator()(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+    {
+        EV << "Functor callback with full arguments\n";
+    }
+};
+
+class Module : public cSimpleModule {
+public:
+    static const simsignal_t mySignal;
+    Module()
+        : cSimpleModule() {};
+    void initialize(int stage) override;
+protected:
+    Veins::SignalManager signalManager;
+};
+
+const simsignal_t Module::mySignal = registerSignal("mySignal");
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto lambdaCallback = [this](cComponent* source, simsignal_t signal, payloadType p, cObject* details) {
+        EV << "Lambda callback with full arguments\n";
+    };
+    // setup all callbacks
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, lambdaCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticEmptyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticPayloadOnlyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticFullCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, functorCallback());
+
+    // emit message to all callbacks
+    emit(Module::mySignal, 0.1);
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+Lambda callback with full arguments
+Static callback with empty arguments
+Static payload-only callback
+Static callback with full arguments
+Functor callback with full arguments

--- a/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_long.test
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_long.test
@@ -1,0 +1,84 @@
+%description
+Ensure CallbackListeners are called.
+
+%file: test.ned
+
+simple Module {
+    @signal[mySignal](type=long);
+}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/SignalManager.h"
+
+namespace @TESTNAME@ {
+
+using payloadType = long;
+
+void staticEmptyCallback()
+{
+    EV << "Static callback with empty arguments\n";
+}
+
+void staticPayloadOnlyCallback(payloadType p)
+{
+    EV << "Static payload-only callback\n";
+}
+
+void staticFullCallback(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+{
+    EV << "Static callback with full arguments\n";
+}
+
+struct functorCallback {
+    void operator()(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+    {
+        EV << "Functor callback with full arguments\n";
+    }
+};
+
+class Module : public cSimpleModule {
+public:
+    static const simsignal_t mySignal;
+    Module()
+        : cSimpleModule() {};
+    void initialize(int stage) override;
+protected:
+    Veins::SignalManager signalManager;
+};
+
+const simsignal_t Module::mySignal = registerSignal("mySignal");
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto lambdaCallback = [this](cComponent* source, simsignal_t signal, payloadType p, cObject* details) {
+        EV << "Lambda callback with full arguments\n";
+    };
+    // setup all callbacks
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, lambdaCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticEmptyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticPayloadOnlyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticFullCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, functorCallback());
+
+    // emit message to all callbacks
+    emit(Module::mySignal, 1<<31);
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+Lambda callback with full arguments
+Static callback with empty arguments
+Static payload-only callback
+Static callback with full arguments
+Functor callback with full arguments

--- a/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_simtime.test
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_simtime.test
@@ -1,0 +1,84 @@
+%description
+Ensure CallbackListeners are called.
+
+%file: test.ned
+
+simple Module {
+    @signal[mySignal](type=simtime_t);
+}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/SignalManager.h"
+
+namespace @TESTNAME@ {
+
+using payloadType = const SimTime&;
+
+void staticEmptyCallback()
+{
+    EV << "Static callback with empty arguments\n";
+}
+
+void staticPayloadOnlyCallback(payloadType p)
+{
+    EV << "Static payload-only callback\n";
+}
+
+void staticFullCallback(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+{
+    EV << "Static callback with full arguments\n";
+}
+
+struct functorCallback {
+    void operator()(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+    {
+        EV << "Functor callback with full arguments\n";
+    }
+};
+
+class Module : public cSimpleModule {
+public:
+    static const simsignal_t mySignal;
+    Module()
+        : cSimpleModule() {};
+    void initialize(int stage) override;
+protected:
+    Veins::SignalManager signalManager;
+};
+
+const simsignal_t Module::mySignal = registerSignal("mySignal");
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto lambdaCallback = [this](cComponent* source, simsignal_t signal, payloadType p, cObject* details) {
+        EV << "Lambda callback with full arguments\n";
+    };
+    // setup all callbacks
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, lambdaCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticEmptyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticPayloadOnlyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticFullCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, functorCallback());
+
+    // emit message to all callbacks
+    emit(Module::mySignal, SimTime(3));
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+Lambda callback with full arguments
+Static callback with empty arguments
+Static payload-only callback
+Static callback with full arguments
+Functor callback with full arguments

--- a/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_string.test
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_string.test
@@ -1,0 +1,84 @@
+%description
+Ensure CallbackListeners are called.
+
+%file: test.ned
+
+simple Module {
+    @signal[mySignal](type=string);
+}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/SignalManager.h"
+
+namespace @TESTNAME@ {
+
+using payloadType = const char*;
+
+void staticEmptyCallback()
+{
+    EV << "Static callback with empty arguments\n";
+}
+
+void staticPayloadOnlyCallback(payloadType p)
+{
+    EV << "Static payload-only callback\n";
+}
+
+void staticFullCallback(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+{
+    EV << "Static callback with full arguments\n";
+}
+
+struct functorCallback {
+    void operator()(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+    {
+        EV << "Functor callback with full arguments\n";
+    }
+};
+
+class Module : public cSimpleModule {
+public:
+    static const simsignal_t mySignal;
+    Module()
+        : cSimpleModule() {};
+    void initialize(int stage) override;
+protected:
+    Veins::SignalManager signalManager;
+};
+
+const simsignal_t Module::mySignal = registerSignal("mySignal");
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto lambdaCallback = [this](cComponent* source, simsignal_t signal, payloadType p, cObject* details) {
+        EV << "Lambda callback with full arguments\n";
+    };
+    // setup all callbacks
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, lambdaCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticEmptyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticPayloadOnlyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticFullCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, functorCallback());
+
+    // emit message to all callbacks
+    emit(Module::mySignal, "test text");
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+Lambda callback with full arguments
+Static callback with empty arguments
+Static payload-only callback
+Static callback with full arguments
+Functor callback with full arguments

--- a/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_ulong.test
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/callbacks_ulong.test
@@ -1,0 +1,84 @@
+%description
+Ensure CallbackListeners are called.
+
+%file: test.ned
+
+simple Module {
+    @signal[mySignal](type=unsigned long);
+}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/SignalManager.h"
+
+namespace @TESTNAME@ {
+
+using payloadType = unsigned long;
+
+void staticEmptyCallback()
+{
+    EV << "Static callback with empty arguments\n";
+}
+
+void staticPayloadOnlyCallback(payloadType p)
+{
+    EV << "Static payload-only callback\n";
+}
+
+void staticFullCallback(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+{
+    EV << "Static callback with full arguments\n";
+}
+
+struct functorCallback {
+    void operator()(cComponent* source, simsignal_t signal, payloadType p, cObject* details)
+    {
+        EV << "Functor callback with full arguments\n";
+    }
+};
+
+class Module : public cSimpleModule {
+public:
+    static const simsignal_t mySignal;
+    Module()
+        : cSimpleModule() {};
+    void initialize(int stage) override;
+protected:
+    Veins::SignalManager signalManager;
+};
+
+const simsignal_t Module::mySignal = registerSignal("mySignal");
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto lambdaCallback = [this](cComponent* source, simsignal_t signal, payloadType p, cObject* details) {
+        EV << "Lambda callback with full arguments\n";
+    };
+    // setup all callbacks
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, lambdaCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticEmptyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticPayloadOnlyCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, staticFullCallback);
+    signalManager.subscribeCallback<payloadType>(getSystemModule(), Module::mySignal, functorCallback());
+
+    // emit message to all callbacks
+    emit(Module::mySignal, static_cast<unsigned long>(-1));
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+Lambda callback with full arguments
+Static callback with empty arguments
+Static payload-only callback
+Static callback with full arguments
+Functor callback with full arguments

--- a/subprojects/veins_testsims/opp_tests/signalmanager/runtest.sh
+++ b/subprojects/veins_testsims/opp_tests/signalmanager/runtest.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+TESTS="*.test"
+VEINS_PATH="../../../../../src/"
+EXTRA_INCLUDES="-I$VEINS_PATH -L$VEINS_PATH"
+
+# ensure the working dir is ready
+mkdir -p work
+
+# generate test files
+opp_test gen -v $TESTS
+
+# build test files
+(cd work; opp_makemake -f --deep -o work $EXTRA_INCLUDES ; make -j4 MODE=debug)
+
+# run tests
+opp_test run -v -p work_dbg $TESTS


### PR DESCRIPTION
This PR add utilities (including documentation and tests) to simplify the usage of OMNeT++ simulation signals.

It works analogously to the TimerManager simplifying usage of self-messages.

Tests are performed using the `opp_test` tool provided by OMNeT++. For more rational and info, see the doc file and tests included in this PR.

Note: If #137 gets merged, the manual page for the features of this PR can easily be included in the user manual from #137 by adding the following to the `doc/manual/manual.md`:
```{doxygen}
* @subpage simsignal_management
```