### PR TITLE
Fix: doxygen warning about recursive relation.

### DIFF
--- a/src/veins/modules/utility/CallableInfo.h
+++ b/src/veins/modules/utility/CallableInfo.h
@@ -19,6 +19,7 @@
 //
 #pragma once
 
+#include <functional>
 #include <tuple>
 #include <type_traits>
 
@@ -41,10 +42,17 @@ struct trait {
     };
 };
 
+// crutch to break up recursive relation that makes doxygen throw errors.
+template <class Lambda>
+struct lambda_type;
+
 // convenience call for lambdas
 template <class Lambda>
-struct type
-    : type<decltype(&Lambda::operator())> {
+struct type : lambda_type<Lambda> {
+};
+
+template <class Lambda>
+struct lambda_type : type<decltype(&Lambda::operator())> {
 };
 
 // for normal functions / function pointer


### PR DESCRIPTION
With the explicit template instantiation for the new `lambda_type`, the warning of doxygen goes away, while all tests still pass as expected.