### PR TITLE
Add traci connection accessor

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -90,6 +90,11 @@ public:
         return commandIfc.get();
     }
 
+    TraCIConnection* getConnection() const
+    {
+        return connection.get();
+    }
+
     bool getAutoShutdownTriggered()
     {
         return autoShutdownTriggered;


### PR DESCRIPTION
This PR introduces an accessor to the `TraCIConnection` that can be used by any module to directly interact with the TraCI server.

The code compiles, passes formatting checks and runs the example successfully.