### PR TITLE
Reintroduce flag indicating traci initialization

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -389,6 +389,7 @@ void TraCIScenarioManager::init_traci()
         }
     }
 
+    traciInitialized = true;
     emit(traciInitializedSignal, true);
 
     // draw and calculate area of rois

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -100,7 +100,18 @@ public:
         return hosts;
     }
 
+    /**
+     * Predicate indicating a successful connection to the TraCI server.
+     *
+     * @note Once the connection has been established, this will return true even when the connection has been torn down again.
+     */
+    bool isUsable() const
+    {
+        return traciInitialized;
+    }
+
 protected:
+    bool traciInitialized = false; /**< Flag indicating whether the init_traci routine has been run. Note that it will change to false again once set, even during shutdown. */
     simtime_t connectAt; /**< when to connect to TraCI server (must be the initial timestep of the server) */
     simtime_t firstStepAt; /**< when to start synchronizing with the TraCI server (-1: immediately after connecting) */
     simtime_t updateInterval; /**< time interval of hosts' position updates */


### PR DESCRIPTION
This PR reintroduces a flag that was removed when the signal mechanism for traci initialization was introduced. While the signal allows a loser coupling of components, it does not enable instantaneous checks for the connection status.