### PR TITLE
Feature/bump traci version

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIBuffer.h
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.h
@@ -5,6 +5,8 @@
 
 #include "veins/veins.h"
 
+#include "veins/modules/mobility/traci/TraCIConstants.h"
+
 namespace Veins {
 
 struct TraCICoord;
@@ -113,9 +115,12 @@ public:
     std::string str() const;
     std::string hexStr() const;
 
-    static void setTimeAsDouble(bool val)
+    static void setTimeType(uint8_t val)
     {
-        timeAsDouble = val;
+        if (val != TraCIConstants::TYPE_INTEGER && val != TraCIConstants::TYPE_DOUBLE) {
+            throw cRuntimeError("Invalid time data type");
+        }
+        timeAsDouble = val == TraCIConstants::TYPE_DOUBLE;
     }
 
 private:

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -50,6 +50,10 @@ public:
     void setApiVersion(uint32_t apiVersion);
     std::pair<double, double> getLonLat(const Coord&);
 
+    unsigned getApiVersion() const
+    {
+        return versionConfig.version;
+    }
     uint8_t getTimeType() const
     {
         return versionConfig.timeType;
@@ -61,10 +65,6 @@ public:
     uint8_t getTimeStepCmd() const
     {
         return versionConfig.timeStepCmd;
-    }
-    bool getHasNewTrafficLightProgramDef() const
-    {
-        return versionConfig.newTrafficLightProgramDef;
     }
 
     std::pair<TraCICoord, TraCICoord> initNetworkBoundaries(int margin);
@@ -467,12 +467,10 @@ public:
 
 private:
     struct VersionConfig {
+        unsigned version;
         uint8_t timeType;
         uint8_t netBoundaryType;
         uint8_t timeStepCmd;
-        bool timeAsDouble;
-        bool screenshotTakesCompound;
-        bool newTrafficLightProgramDef;
     };
 
     TraCIConnection& connection;

--- a/src/veins/modules/world/traci/trafficLight/TraCITrafficLightProgram.h
+++ b/src/veins/modules/world/traci/trafficLight/TraCITrafficLightProgram.h
@@ -37,6 +37,7 @@ public:
         simtime_t minDuration;
         simtime_t maxDuration;
         int32_t next;
+        std::string name;
 
         bool isGreenPhase() const;
     };

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -122,8 +122,10 @@ void TraCITestApp::handlePositionUpdate()
 
     if (testNumber == testCounter++) {
         if (t == 1) {
-            assertClose("(TraCICommandInterface::getDistance) air", 859., floor(traci->getDistance(Coord(25, 7030), Coord(883, 6980), false)));
-            assertClose("(TraCICommandInterface::getDistance) driving", 847., floor(traci->getDistance(Coord(25, 7030), Coord(883, 6980), true)));
+            const Coord pointA(27.6, 76.65);
+            const Coord pointB(631.41, 26.65);
+            assertClose("(TraCICommandInterface::getDistance) air", 605., floor(traci->getDistance(pointA, pointB, false)));
+            assertClose("(TraCICommandInterface::getDistance) driving", 650., floor(traci->getDistance(pointA, pointB, true)));
         }
     }
 
@@ -304,7 +306,7 @@ void TraCITestApp::handlePositionUpdate()
             traciVehicle->setMaxSpeed(1 / 3.6);
         }
         if (t == 30) {
-            assertClose("(TraCICommandInterface::Vehicle::setMaxSpeed)", 0.2280344208055693489, mobility->getSpeed());
+            assertTrue("(TraCICommandInterface::Vehicle::setMaxSpeed)", mobility->getSpeed() <= 1 / 3.6);
         }
     }
 


### PR DESCRIPTION
This PR reworks how different TraCI API versions are handled in the TraCI module, since the current method is not maintainable. Also, this adds support for the recently introduced API version 20.