### PR TITLE
Introduce parameter for modifying forker sumo command

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.cc
@@ -71,6 +71,7 @@ void TraCIScenarioManagerForker::initialize(int stage)
 {
     if (stage == 1) {
         commandLine = par("commandLine").stringValue();
+        command = par("command").stringValue();
         configFile = par("configFile").stringValue();
         seed = par("seed");
         killServer();
@@ -126,6 +127,7 @@ void TraCIScenarioManagerForker::startServer()
     }
 
     // assemble commandLine
+    commandLine = replace(commandLine, "$command", command);
     commandLine = replace(commandLine, "$configFile", configFile);
     commandLine = replace(commandLine, "$seed", seed);
     commandLine = replace(commandLine, "$port", port);

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.h
@@ -51,6 +51,7 @@ public:
 
 protected:
     std::string commandLine; /**< command line for running TraCI server (substituting $configFile, $seed, $port) */
+    std::string command; /**< substitution for $command parameter */
     std::string configFile; /**< substitution for $configFile parameter */
     int seed; /**< substitution for $seed parameter (-1: current run number) */
 

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.ned
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.ned
@@ -36,7 +36,8 @@ simple TraCIScenarioManagerForker extends TraCIScenarioManager
 {
     parameters:
         @class(veins::TraCIScenarioManagerForker);
-        string commandLine = default("sumo --remote-port $port --seed $seed --configuration-file $configFile"); // command line for running TraCI server (substituting $configFile, $seed, $port)
+        string commandLine = default("$command --remote-port $port --seed $seed --configuration-file $configFile"); // command line for running TraCI server (substituting $command, $configFile, $seed, $port)
+        string command = default("sumo"); // substitution for $command parameter
         string configFile = default("my.sumo.cfg"); // substitution for $configFile parameter
         port = default(-1);  // substitution for $port parameter (-1: autodetect)
 }


### PR DESCRIPTION
This PR introduces a parameter to the `TraCIScenarioManagerForker` which allows modifying the sumo command that is used. This allows to, e.g., use `sumo-gui` or the sumo binary with debug symbols (`sumoD`) instead.