### PR TITLE
[WIP] Improve performance of the obstacle shadowing model

### DIFF
--- a/src/veins/modules/obstacle/Obstacle.cc
+++ b/src/veins/modules/obstacle/Obstacle.cc
@@ -52,12 +52,12 @@ const Obstacle::Coords& Obstacle::getShape() const
     return coords;
 }
 
-const Coord Obstacle::getBboxP1() const
+const Coord& Obstacle::getBboxP1() const
 {
     return bboxP1;
 }
 
-const Coord Obstacle::getBboxP2() const
+const Coord& Obstacle::getBboxP2() const
 {
     return bboxP2;
 }
@@ -82,7 +82,7 @@ bool Obstacle::containsPoint(Coord point) const
 
 namespace {
 
-double segmentsIntersectAt(Coord p1From, Coord p1To, Coord p2From, Coord p2To)
+double segmentsIntersectAt(const Coord& p1From, const Coord& p1To, const Coord& p2From, const Coord& p2To)
 {
     Coord p1Vec = p1To - p1From;
     Coord p2Vec = p2To - p2From;
@@ -108,8 +108,8 @@ std::multiset<double> Obstacle::getIntersections(const Coord& senderPos, const C
     Obstacle::Coords::const_iterator i = shape.begin();
     Obstacle::Coords::const_iterator j = (shape.rbegin() + 1).base();
     for (; i != shape.end(); j = i++) {
-        Coord c1 = *i;
-        Coord c2 = *j;
+        const Coord& c1 = *i;
+        const Coord& c2 = *j;
 
         double i = segmentsIntersectAt(senderPos, receiverPos, c1, c2);
         if (i != -1) {

--- a/src/veins/modules/obstacle/Obstacle.cc
+++ b/src/veins/modules/obstacle/Obstacle.cc
@@ -84,16 +84,19 @@ namespace {
 
 double segmentsIntersectAt(const Coord& p1From, const Coord& p1To, const Coord& p2From, const Coord& p2To)
 {
-    Coord p1Vec = p1To - p1From;
-    Coord p2Vec = p2To - p2From;
-    Coord p1p2 = p1From - p2From;
+    const double p1_x = p1To.x - p1From.x;
+    const double p1_y = p1To.y - p1From.y;
+    const double p2_x = p2To.x - p2From.x;
+    const double p2_y = p2To.y - p2From.y;
+    const double p1p2_x = p1From.x - p2From.x;
+    const double p1p2_y = p1From.y - p2From.y;
 
-    double D = (p1Vec.x * p2Vec.y - p1Vec.y * p2Vec.x);
+    double D = (p1_x * p2_y - p1_y * p2_x);
 
-    double p1Frac = (p2Vec.x * p1p2.y - p2Vec.y * p1p2.x) / D;
+    double p1Frac = (p2_x * p1p2_y - p2_y * p1p2_x) / D;
     if (p1Frac < 0 || p1Frac > 1) return -1;
 
-    double p2Frac = (p1Vec.x * p1p2.y - p1Vec.y * p1p2.x) / D;
+    double p2Frac = (p1_x * p1p2_y - p1_y * p1p2_x) / D;
     if (p2Frac < 0 || p2Frac > 1) return -1;
 
     return p1Frac;

--- a/src/veins/modules/obstacle/Obstacle.h
+++ b/src/veins/modules/obstacle/Obstacle.h
@@ -37,8 +37,8 @@ public:
 
     void setShape(Coords shape);
     const Coords& getShape() const;
-    const Coord getBboxP1() const;
-    const Coord getBboxP2() const;
+    const Coord& getBboxP1() const;
+    const Coord& getBboxP2() const;
     bool containsPoint(Coord Point) const;
 
     std::string getType() const;

--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -205,9 +205,7 @@ std::map<veins::Obstacle*, std::multiset<double>> ObstacleControl::getIntersecti
         for (size_t row = fromRow; row <= toRow; ++row) {
             if (row >= obstacles[col].size()) break;
             const ObstacleGridCell& cell = (obstacles[col])[row];
-            for (ObstacleGridCell::const_iterator k = cell.begin(); k != cell.end(); ++k) {
-                Obstacle* o = *k;
-
+            for (const auto& o: cell) {
                 // bail if already checked
                 if (processedObstacles.find(o) != processedObstacles.end()) continue;
                 processedObstacles.insert(o);

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -97,7 +97,7 @@ protected:
         GRIDCELL_SIZE = 1024
     };
 
-    using ObstacleGridCell = std::list<Obstacle*>;
+    using ObstacleGridCell = std::vector<Obstacle*>;
     using ObstacleGridRow = std::vector<ObstacleGridCell>;
     using Obstacles = std::vector<ObstacleGridRow>;
     typedef std::map<CacheKey, double> CacheEntries;


### PR DESCRIPTION
The obstacle shadowing model seems to be the dominant bottleneck in urban scenarios. This PR improves its implementation to be faster.

E.g., in the Paderborn scenario with 1Hz beaconing rate, this yields an overall speedup of the simulation of ~25%.

Detailed validation and performance checks on other scenarios are still t.b.d., so this is only a draft for now.