### PR TITLE
Make obstacle grid cell size a parameter.

### DIFF
--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -42,6 +42,7 @@ void ObstacleControl::initialize(int stage)
         if (annotations) annotationGroup = annotations->createGroup("obstacles");
 
         obstaclesXml = par("obstacles");
+        gridCellSize = par("gridCellSize");
 
         addFromXml(obstaclesXml);
     }
@@ -140,10 +141,10 @@ void ObstacleControl::add(Obstacle obstacle)
     Obstacle* o = new Obstacle(obstacle);
     obstacleOwner.emplace_back(o);
 
-    size_t fromRow = std::max(0, int(o->getBboxP1().x / GRIDCELL_SIZE));
-    size_t toRow = std::max(0, int(o->getBboxP2().x / GRIDCELL_SIZE));
-    size_t fromCol = std::max(0, int(o->getBboxP1().y / GRIDCELL_SIZE));
-    size_t toCol = std::max(0, int(o->getBboxP2().y / GRIDCELL_SIZE));
+    size_t fromRow = std::max(0, int(o->getBboxP1().x / gridCellSize));
+    size_t toRow = std::max(0, int(o->getBboxP2().x / gridCellSize));
+    size_t fromCol = std::max(0, int(o->getBboxP1().y / gridCellSize));
+    size_t toCol = std::max(0, int(o->getBboxP2().y / gridCellSize));
     for (size_t row = fromRow; row <= toRow; ++row) {
         for (size_t col = fromCol; col <= toCol; ++col) {
             if (obstacles.size() < col + 1) obstacles.resize(col + 1);
@@ -194,10 +195,10 @@ std::map<veins::Obstacle*, std::multiset<double>> ObstacleControl::getIntersecti
     Coord bboxP1 = Coord(std::min(senderPos.x, receiverPos.x), std::min(senderPos.y, receiverPos.y));
     Coord bboxP2 = Coord(std::max(senderPos.x, receiverPos.x), std::max(senderPos.y, receiverPos.y));
 
-    size_t fromRow = std::max(0, int(bboxP1.x / GRIDCELL_SIZE));
-    size_t toRow = std::max(0, int(bboxP2.x / GRIDCELL_SIZE));
-    size_t fromCol = std::max(0, int(bboxP1.y / GRIDCELL_SIZE));
-    size_t toCol = std::max(0, int(bboxP2.y / GRIDCELL_SIZE));
+    size_t fromRow = std::max(0, int(bboxP1.x / gridCellSize));
+    size_t toRow = std::max(0, int(bboxP2.x / gridCellSize));
+    size_t fromCol = std::max(0, int(bboxP1.y / gridCellSize));
+    size_t toCol = std::max(0, int(bboxP2.y / gridCellSize));
 
     std::set<Obstacle*> processedObstacles;
     for (size_t col = fromCol; col <= toCol; ++col) {

--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -43,6 +43,9 @@ void ObstacleControl::initialize(int stage)
 
         obstaclesXml = par("obstacles");
         gridCellSize = par("gridCellSize");
+        if (gridCellSize < 1) {
+            throw cRuntimeError("gridCellSize was %d, but must be a positive integer number", gridCellSize);
+        }
 
         addFromXml(obstaclesXml);
     }

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -93,16 +93,13 @@ protected:
         }
     };
 
-    enum {
-        GRIDCELL_SIZE = 1024
-    };
-
     using ObstacleGridCell = std::list<Obstacle*>;
     using ObstacleGridRow = std::vector<ObstacleGridCell>;
     using Obstacles = std::vector<ObstacleGridRow>;
     typedef std::map<CacheKey, double> CacheEntries;
 
     cXMLElement* obstaclesXml; /**< obstacles to add at startup */
+    unsigned int gridCellSize = 1024; /// size of square grid tiles for obstacle store
 
     Obstacles obstacles;
     std::vector<std::unique_ptr<Obstacle>> obstacleOwner;

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -99,7 +99,7 @@ protected:
     typedef std::map<CacheKey, double> CacheEntries;
 
     cXMLElement* obstaclesXml; /**< obstacles to add at startup */
-    unsigned int gridCellSize = 1024; /// size of square grid tiles for obstacle store
+    int gridCellSize = 1024; /// size of square grid tiles for obstacle store
 
     Obstacles obstacles;
     std::vector<std::unique_ptr<Obstacle>> obstacleOwner;

--- a/src/veins/modules/obstacle/ObstacleControl.ned
+++ b/src/veins/modules/obstacle/ObstacleControl.ned
@@ -28,6 +28,7 @@ simple ObstacleControl
     parameters:
         @class(veins::ObstacleControl);
         xml obstacles = default(xml("<obstacles/>")); // list of obstacle types and obstacles to load
+        int gridCellSize = default(1024); // size of square grid tiles for obstacle store
         @display("i=misc/town");
         @labels(node);
 }


### PR DESCRIPTION
Tuning this can reduce simulation time without change in results.

E.g., in an urban scenario like Paderborn, reducing the grid cell size to 128 or 256 also reduces the execution time and number of instructions performed by >20%.

Default behavior is unchanged.