### PR TITLE
Fast obstacle shadowing

### DIFF
--- a/src/veins/modules/obstacle/Obstacle.cc
+++ b/src/veins/modules/obstacle/Obstacle.cc
@@ -18,8 +18,9 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //
 
-#include "veins/modules/obstacle/Obstacle.h"
 #include <algorithm>
+
+#include "veins/modules/obstacle/Obstacle.h"
 
 using namespace veins;
 
@@ -82,18 +83,20 @@ bool Obstacle::containsPoint(Coord point) const
 
 namespace {
 
-double segmentsIntersectAt(Coord p1From, Coord p1To, Coord p2From, Coord p2To)
+double segmentsIntersectAt(const Coord& p1From, const Coord& p1To, const Coord& p2From, const Coord& p2To)
 {
-    Coord p1Vec = p1To - p1From;
-    Coord p2Vec = p2To - p2From;
-    Coord p1p2 = p1From - p2From;
+    double p1x = p1To.x - p1From.x;
+    double p1y = p1To.y - p1From.y;
+    double p2x = p2To.x - p2From.x;
+    double p2y = p2To.y - p2From.y;
+    double p1p2x = p1From.x - p2From.x;
+    double p1p2y = p1From.y - p2From.y;
+    double D = (p1x * p2y - p1y * p2x);
 
-    double D = (p1Vec.x * p2Vec.y - p1Vec.y * p2Vec.x);
-
-    double p1Frac = (p2Vec.x * p1p2.y - p2Vec.y * p1p2.x) / D;
+    double p1Frac = (p2x * p1p2y - p2y * p1p2x) / D;
     if (p1Frac < 0 || p1Frac > 1) return -1;
 
-    double p2Frac = (p1Vec.x * p1p2.y - p1Vec.y * p1p2.x) / D;
+    double p2Frac = (p1x * p1p2y - p1y * p1p2x) / D;
     if (p2Frac < 0 || p2Frac > 1) return -1;
 
     return p1Frac;
@@ -107,8 +110,8 @@ std::vector<double> Obstacle::getIntersections(const Coord& senderPos, const Coo
     Obstacle::Coords::const_iterator i = shape.begin();
     Obstacle::Coords::const_iterator j = (shape.rbegin() + 1).base();
     for (; i != shape.end(); j = i++) {
-        Coord c1 = *i;
-        Coord c2 = *j;
+        const Coord& c1 = *i;
+        const Coord& c2 = *j;
 
         double i = segmentsIntersectAt(senderPos, receiverPos, c1, c2);
         if (i != -1) {

--- a/src/veins/modules/obstacle/Obstacle.cc
+++ b/src/veins/modules/obstacle/Obstacle.cc
@@ -18,8 +18,8 @@
 // Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 //
 
-#include <set>
 #include "veins/modules/obstacle/Obstacle.h"
+#include <algorithm>
 
 using namespace veins;
 
@@ -100,10 +100,9 @@ double segmentsIntersectAt(Coord p1From, Coord p1To, Coord p2From, Coord p2To)
 }
 } // namespace
 
-std::multiset<double> Obstacle::getIntersections(const Coord& senderPos, const Coord& receiverPos) const
+std::vector<double> Obstacle::getIntersections(const Coord& senderPos, const Coord& receiverPos) const
 {
-    std::multiset<double> intersectAt;
-    bool doesIntersect = false;
+    std::vector<double> intersectAt;
     const Obstacle::Coords& shape = getShape();
     Obstacle::Coords::const_iterator i = shape.begin();
     Obstacle::Coords::const_iterator j = (shape.rbegin() + 1).base();
@@ -113,10 +112,10 @@ std::multiset<double> Obstacle::getIntersections(const Coord& senderPos, const C
 
         double i = segmentsIntersectAt(senderPos, receiverPos, c1, c2);
         if (i != -1) {
-            doesIntersect = true;
-            intersectAt.insert(i);
+            intersectAt.push_back(i);
         }
     }
+    std::sort(intersectAt.begin(), intersectAt.end());
     return intersectAt;
 }
 

--- a/src/veins/modules/obstacle/Obstacle.h
+++ b/src/veins/modules/obstacle/Obstacle.h
@@ -21,6 +21,9 @@
 #pragma once
 
 #include <vector>
+
+#include "veins/veins.h"
+
 #include "veins/base/utils/Coord.h"
 #include "veins/modules/world/annotations/AnnotationManager.h"
 

--- a/src/veins/modules/obstacle/Obstacle.h
+++ b/src/veins/modules/obstacle/Obstacle.h
@@ -49,7 +49,7 @@ public:
     /**
      * get a list of points (in [0, 1]) along the line between sender and receiver where the beam intersects with this obstacle
      */
-    std::multiset<double> getIntersections(const Coord& senderPos, const Coord& receiverPos) const;
+    std::vector<double> getIntersections(const Coord& senderPos, const Coord& receiverPos) const;
 
     AnnotationManager::Annotation* visualRepresentation;
 

--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -23,10 +23,25 @@
 #include <set>
 
 #include "veins/modules/obstacle/ObstacleControl.h"
+#include "veins/base/modules/BaseWorldUtility.h"
 
 using veins::ObstacleControl;
 
 Define_Module(veins::ObstacleControl);
+
+namespace {
+
+veins::BBoxLookup rebuildBBoxLookup(const std::vector<std::unique_ptr<veins::Obstacle>>& obstacleOwner, int gridCellSize = 250)
+{
+    std::vector<veins::Obstacle*> obstaclePointers;
+    obstaclePointers.reserve(obstacleOwner.size());
+    std::transform(obstacleOwner.begin(), obstacleOwner.end(), std::back_inserter(obstaclePointers), [](const std::unique_ptr<veins::Obstacle>& obstacle) { return obstacle.get(); });
+    auto playgroundSize = veins::FindModule<veins::BaseWorldUtility*>::findGlobalModule()->getPgs();
+    auto bboxFunction = [](veins::Obstacle* o) { return veins::BBoxLookup::Box{{o->getBboxP1().x, o->getBboxP1().y}, {o->getBboxP2().x, o->getBboxP2().y}}; };
+    return veins::BBoxLookup(obstaclePointers, bboxFunction, playgroundSize->x, playgroundSize->y, gridCellSize);
+}
+
+} // anonymous namespace
 
 ObstacleControl::~ObstacleControl()
 {
@@ -35,13 +50,18 @@ ObstacleControl::~ObstacleControl()
 void ObstacleControl::initialize(int stage)
 {
     if (stage == 1) {
-        obstacles.clear();
+        obstacleOwner.clear();
         cacheEntries.clear();
+        isBboxLookupDirty = true;
 
         annotations = AnnotationManagerAccess().getIfExists();
         if (annotations) annotationGroup = annotations->createGroup("obstacles");
 
         obstaclesXml = par("obstacles");
+        gridCellSize = par("gridCellSize");
+        if (gridCellSize < 1) {
+            throw cRuntimeError("gridCellSize was %d, but must be a positive integer number", gridCellSize);
+        }
 
         addFromXml(obstaclesXml);
     }
@@ -50,7 +70,6 @@ void ObstacleControl::initialize(int stage)
 void ObstacleControl::finish()
 {
     obstacleOwner.clear();
-    obstacles.clear();
 }
 
 void ObstacleControl::handleMessage(cMessage* msg)
@@ -140,40 +159,15 @@ void ObstacleControl::add(Obstacle obstacle)
     Obstacle* o = new Obstacle(obstacle);
     obstacleOwner.emplace_back(o);
 
-    size_t fromRow = std::max(0, int(o->getBboxP1().x / GRIDCELL_SIZE));
-    size_t toRow = std::max(0, int(o->getBboxP2().x / GRIDCELL_SIZE));
-    size_t fromCol = std::max(0, int(o->getBboxP1().y / GRIDCELL_SIZE));
-    size_t toCol = std::max(0, int(o->getBboxP2().y / GRIDCELL_SIZE));
-    for (size_t row = fromRow; row <= toRow; ++row) {
-        for (size_t col = fromCol; col <= toCol; ++col) {
-            if (obstacles.size() < col + 1) obstacles.resize(col + 1);
-            if (obstacles[col].size() < row + 1) obstacles[col].resize(row + 1);
-            (obstacles[col])[row].push_back(o);
-        }
-    }
-
     // visualize using AnnotationManager
     if (annotations) o->visualRepresentation = annotations->drawPolygon(o->getShape(), "red", annotationGroup);
 
     cacheEntries.clear();
+    isBboxLookupDirty = true;
 }
 
 void ObstacleControl::erase(const Obstacle* obstacle)
 {
-    for (Obstacles::iterator i = obstacles.begin(); i != obstacles.end(); ++i) {
-        for (ObstacleGridRow::iterator j = i->begin(); j != i->end(); ++j) {
-            for (ObstacleGridCell::iterator k = j->begin(); k != j->end();) {
-                Obstacle* o = *k;
-                if (o == obstacle) {
-                    k = j->erase(k);
-                }
-                else {
-                    ++k;
-                }
-            }
-        }
-    }
-
     if (annotations && obstacle->visualRepresentation) annotations->erase(obstacle->visualRepresentation);
     for (auto itOwner = obstacleOwner.begin(); itOwner != obstacleOwner.end(); ++itOwner) {
         // find owning pointer and remove it to deallocate obstacle
@@ -184,49 +178,33 @@ void ObstacleControl::erase(const Obstacle* obstacle)
     }
 
     cacheEntries.clear();
+    isBboxLookupDirty = true;
 }
 
-std::map<veins::Obstacle*, std::multiset<double>> ObstacleControl::getIntersections(const Coord& senderPos, const Coord& receiverPos) const
+std::vector<std::pair<veins::Obstacle*, std::vector<double>>> ObstacleControl::getIntersections(const Coord& senderPos, const Coord& receiverPos) const
 {
-    std::map<veins::Obstacle*, std::multiset<double>> allIntersections;
+    std::vector<std::pair<Obstacle*, std::vector<double>>> allIntersections;
 
-    // calculate bounding box of transmission
-    Coord bboxP1 = Coord(std::min(senderPos.x, receiverPos.x), std::min(senderPos.y, receiverPos.y));
-    Coord bboxP2 = Coord(std::max(senderPos.x, receiverPos.x), std::max(senderPos.y, receiverPos.y));
-
-    size_t fromRow = std::max(0, int(bboxP1.x / GRIDCELL_SIZE));
-    size_t toRow = std::max(0, int(bboxP2.x / GRIDCELL_SIZE));
-    size_t fromCol = std::max(0, int(bboxP1.y / GRIDCELL_SIZE));
-    size_t toCol = std::max(0, int(bboxP2.y / GRIDCELL_SIZE));
-
-    std::set<Obstacle*> processedObstacles;
-    for (size_t col = fromCol; col <= toCol; ++col) {
-        if (col >= obstacles.size()) break;
-        for (size_t row = fromRow; row <= toRow; ++row) {
-            if (row >= obstacles[col].size()) break;
-            const ObstacleGridCell& cell = (obstacles[col])[row];
-            for (ObstacleGridCell::const_iterator k = cell.begin(); k != cell.end(); ++k) {
-                Obstacle* o = *k;
-
-                // bail if already checked
-                if (processedObstacles.find(o) != processedObstacles.end()) continue;
-                processedObstacles.insert(o);
-
-                // bail if bounding boxes cannot overlap
-                if (o->getBboxP2().x < bboxP1.x) continue;
-                if (o->getBboxP1().x > bboxP2.x) continue;
-                if (o->getBboxP2().y < bboxP1.y) continue;
-                if (o->getBboxP1().y > bboxP2.y) continue;
-
-                // if obstacles has neither borders nor matter: bail.
-                if (o->getShape().size() < 2) continue;
-
-                // add intersections
-                allIntersections[o] = o->getIntersections(senderPos, receiverPos);
-            }
-        }
+    // rebuild bounding box lookup structure if dirty (new obstacles added recently)
+    if (isBboxLookupDirty) {
+        bboxLookup = rebuildBBoxLookup(obstacleOwner);
+        isBboxLookupDirty = false;
     }
 
+    auto candidateObstacles = bboxLookup.findOverlapping({senderPos.x, senderPos.y}, {receiverPos.x, receiverPos.y});
+
+    // remove duplicates
+    sort(candidateObstacles.begin(), candidateObstacles.end());
+    candidateObstacles.erase(unique(candidateObstacles.begin(), candidateObstacles.end()), candidateObstacles.end());
+
+    for (Obstacle* o : candidateObstacles) {
+        // if obstacles has neither borders nor matter: bail.
+        if (o->getShape().size() < 2) continue;
+        auto foundIntersections = o->getIntersections(senderPos, receiverPos);
+        if (!foundIntersections.empty() || o->containsPoint(senderPos) || o->containsPoint(receiverPos)) {
+            allIntersections.emplace_back(o, foundIntersections);
+        }
+    }
     return allIntersections;
 }
 
@@ -237,17 +215,19 @@ double ObstacleControl::calculateAttenuation(const Coord& senderPos, const Coord
     if ((perCut.size() == 0) || (perMeter.size() == 0)) {
         throw cRuntimeError("Unable to use SimpleObstacleShadowing: No obstacle types have been configured");
     }
-    if (obstacles.size() == 0) {
+    if (obstacleOwner.size() == 0) {
         throw cRuntimeError("Unable to use SimpleObstacleShadowing: No obstacles have been added");
     }
 
     // return cached result, if available
     CacheKey cacheKey(senderPos, receiverPos);
     CacheEntries::const_iterator cacheEntryIter = cacheEntries.find(cacheKey);
-    if (cacheEntryIter != cacheEntries.end()) return cacheEntryIter->second;
+    if (cacheEntryIter != cacheEntries.end()) {
+        return cacheEntryIter->second;
+    }
 
     // get intersections
-    std::map<veins::Obstacle*, std::multiset<double>> intersections = getIntersections(senderPos, receiverPos);
+    auto intersections = getIntersections(senderPos, receiverPos);
 
     double factor = 1;
     for (auto i = intersections.begin(); i != intersections.end(); ++i) {
@@ -263,13 +243,13 @@ double ObstacleControl::calculateAttenuation(const Coord& senderPos, const Coord
         double numCuts = intersectAt.size();
 
         // for distance calculation, make sure every other pair of points marks transition through matter and void, respectively.
-        if (senderInside) intersectAt.insert(0);
-        if (receiverInside) intersectAt.insert(1);
+        if (senderInside) intersectAt.insert(intersectAt.begin(), 0);
+        if (receiverInside) intersectAt.push_back(1);
         ASSERT((intersectAt.size() % 2) == 0);
 
         // sum up distances in matter.
         double fractionInObstacle = 0;
-        for (std::multiset<double>::const_iterator i = intersectAt.begin(); i != intersectAt.end();) {
+        for (auto i = intersectAt.begin(); i != intersectAt.end();) {
             double p1 = *(i++);
             double p2 = *(i++);
             fractionInObstacle += (p2 - p1);

--- a/src/veins/modules/obstacle/ObstacleControl.ned
+++ b/src/veins/modules/obstacle/ObstacleControl.ned
@@ -28,6 +28,7 @@ simple ObstacleControl
     parameters:
         @class(veins::ObstacleControl);
         xml obstacles = default(xml("<obstacles/>")); // list of obstacle types and obstacles to load
+        int gridCellSize = default(250); // size of square grid tiles for obstacle store
         @display("i=misc/town");
         @labels(node);
 }

--- a/src/veins/modules/utility/BBoxLookup.cc
+++ b/src/veins/modules/utility/BBoxLookup.cc
@@ -1,0 +1,197 @@
+//
+// Copyright (C) 2019 Dominik S. Buse <buse@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#include <cmath>
+
+#include "veins/modules/utility/BBoxLookup.h"
+
+namespace {
+
+using Point = veins::BBoxLookup::Point;
+using Box = veins::BBoxLookup::Box;
+
+/**
+ * Helper structure representing a wireless ray from a sender to a receiver.
+ *
+ * Contains pre-computed values to speed up calls to intersect with the same ray but different boxes.
+ */
+struct Ray {
+    Point origin;
+    Point destination;
+    Point direction;
+    Point invDirection;
+    struct {
+        size_t x;
+        size_t y;
+    } sign;
+    double length;
+};
+
+/**
+ * Return a Ray struct for fast intersection tests from sender to receiver.
+ */
+Ray makeRay(const Point& sender, const Point& receiver)
+{
+    const double dir_x = receiver.x - sender.x;
+    const double dir_y = receiver.y - sender.y;
+    Ray ray;
+    ray.origin = sender;
+    ray.destination = receiver;
+    ray.length = std::sqrt(dir_x * dir_x + dir_y * dir_y);
+    ray.direction.x = dir_x / ray.length;
+    ray.direction.y = dir_y / ray.length;
+    ray.invDirection.x = 1.0 / ray.direction.x;
+    ray.invDirection.y = 1.0 / ray.direction.y;
+    ray.sign.x = ray.invDirection.x < 0;
+    ray.sign.y = ray.invDirection.y < 0;
+    return ray;
+}
+/**
+ * Return whether ray intersects with box.
+ *
+ * Based on:
+ * Amy Williams, Steve Barrus, R. Keith Morley & Peter Shirley (2005) An Efficient and Robust Ray-Box Intersection Algorithm, Journal of Graphics Tools, 10:1, 49-54, DOI: 10.1080/2151237X.2005.10129188
+ */
+bool intersects(const Ray& ray, const Box& box)
+{
+    const double x[2]{box.p1.x, box.p2.x};
+    const double y[2]{box.p1.y, box.p2.y};
+    double tmin = (x[ray.sign.x] - ray.origin.x) * ray.invDirection.x;
+    double tmax = (x[1 - ray.sign.x] - ray.origin.x) * ray.invDirection.x;
+    double tymin = (y[ray.sign.y] - ray.origin.y) * ray.invDirection.y;
+    double tymax = (y[1 - ray.sign.y] - ray.origin.y) * ray.invDirection.y;
+
+    if ((tmin > tymax) || (tymin > tmax)) return false;
+    if (tymin > tmin) tmin = tymin;
+    if (tymax < tmax) tmax = tymax;
+    return (tmin < ray.length) && (tmax > 0);
+}
+
+} // anonymous namespace
+
+namespace veins {
+
+BBoxLookup::BBoxLookup(const std::vector<Obstacle*>& obstacles, std::function<BBoxLookup::Box(Obstacle*)> makeBBox, double scenarioX, double scenarioY, int cellSize)
+    : bboxes()
+    , obstacleLookup()
+    , bboxCells()
+    , cellSize(cellSize)
+    , numCols(std::ceil(scenarioX / cellSize))
+    , numRows(std::ceil(scenarioY / cellSize))
+{
+    // phase 1: build unordered collection of cells
+    // initialize proto-cells (cells in non-contiguos memory)
+    ASSERT(scenarioX > 0);
+    ASSERT(scenarioY > 0);
+    ASSERT(numCols * cellSize >= scenarioX);
+    ASSERT(numRows * cellSize >= scenarioY);
+    const size_t numCells = numCols * numRows;
+    std::vector<std::vector<BBoxLookup::Box>> protoCells(numCells);
+    std::vector<std::vector<Obstacle*>> protoLookup(numCells);
+    // fill protoCells with boundingBoxes
+    size_t numEntries = 0;
+    for (const auto obstaclePtr : obstacles) {
+        auto bbox = makeBBox(obstaclePtr);
+        const size_t fromCol = std::max(0, int(bbox.p1.x / cellSize));
+        const size_t toCol = std::max(0, int(bbox.p2.x / cellSize));
+        const size_t fromRow = std::max(0, int(bbox.p1.y / cellSize));
+        const size_t toRow = std::max(0, int(bbox.p2.y / cellSize));
+        for (size_t row = fromRow; row <= toRow; ++row) {
+            for (size_t col = fromCol; col <= toCol; ++col) {
+                const size_t cellIndex = col + row * numCols;
+                protoCells[cellIndex].push_back(bbox);
+                protoLookup[cellIndex].push_back(obstaclePtr);
+                ++numEntries;
+                ASSERT(protoCells[cellIndex].size() == protoLookup[cellIndex].size());
+            }
+        }
+    }
+
+    // phase 2: derive read-only data structure with fast lookup
+    bboxes.reserve(numEntries);
+    obstacleLookup.reserve(numEntries);
+    bboxCells.reserve(numCells);
+    size_t index = 0;
+    for (size_t row = 0; row < numRows; ++row) {
+        for (size_t col = 0; col < numCols; ++col) {
+            const size_t cellIndex = col + row * numCols;
+            auto& currentCell = protoCells.at(cellIndex);
+            auto& currentLookup = protoLookup.at(cellIndex);
+            ASSERT(currentCell.size() == currentLookup.size());
+            const size_t count = currentCell.size();
+            // copy over bboxes and obstacle lookups (in strict order)
+            for (size_t entryIndex = 0; entryIndex < count; ++entryIndex) {
+                bboxes.push_back(currentCell.at(entryIndex));
+                obstacleLookup.push_back(currentLookup.at(entryIndex));
+            }
+            // create lookup table for this cell
+            bboxCells.push_back({index, count});
+            // forward index to begin of next cell
+            index += count;
+            ASSERT(bboxes.size() == index);
+        }
+    }
+    ASSERT(bboxes.size() == numEntries);
+    ASSERT(bboxes.size() == obstacleLookup.size());
+}
+
+std::vector<Obstacle*> BBoxLookup::findOverlapping(Point sender, Point receiver) const
+{
+    std::vector<Obstacle*> overlappingObstacles;
+    const Box bbox{
+        {std::min(sender.x, receiver.x), std::min(sender.y, receiver.y)},
+        {std::max(sender.x, receiver.x), std::max(sender.y, receiver.y)},
+    };
+
+    // determine coordinates for all cells touched by bbox
+    const size_t firstCol = std::max(0, int(bbox.p1.x / cellSize));
+    const size_t lastCol = std::max(0, int(bbox.p2.x / cellSize));
+    const size_t firstRow = std::max(0, int(bbox.p1.y / cellSize));
+    const size_t lastRow = std::max(0, int(bbox.p2.y / cellSize));
+    ASSERT(lastCol < numCols && lastRow < numRows);
+    // precompute transmission ray properties
+    const Ray ray = makeRay(sender, receiver);
+    // iterate over cells
+    for (size_t row = firstRow; row <= lastRow; ++row) {
+        for (size_t col = firstCol; col <= lastCol; ++col) {
+            // skip cell if ray does not intersect with the cell.
+            const Box cellBox = {{static_cast<double>(col * cellSize), static_cast<double>(row * cellSize)}, {static_cast<double>((col + 1) * cellSize), static_cast<double>((row + 1) * cellSize)}};
+            if (!intersects(ray, cellBox)) continue;
+            // derive cell for current cell coordinates
+            const size_t cellIndex = col + row * numCols;
+            const BBoxCell& cell = bboxCells.at(cellIndex);
+            // iterate over bboxes in each cell
+            for (size_t bboxIndex = cell.index; bboxIndex < cell.index + cell.count; ++bboxIndex) {
+                const Box& current = bboxes.at(bboxIndex);
+                // check for overlap with bbox (fast rejection)
+                if (current.p2.x < bbox.p1.x) continue;
+                if (current.p1.x > bbox.p2.x) continue;
+                if (current.p2.y < bbox.p1.y) continue;
+                if (current.p1.y > bbox.p2.y) continue;
+                // derive corresponding obstacle
+                if (!intersects(ray, current)) continue;
+                overlappingObstacles.push_back(obstacleLookup.at(bboxIndex));
+            }
+        }
+    }
+    return overlappingObstacles;
+}
+
+} // namespace veins

--- a/src/veins/modules/utility/BBoxLookup.h
+++ b/src/veins/modules/utility/BBoxLookup.h
@@ -1,0 +1,82 @@
+//
+// Copyright (C) 2019 Dominik S. Buse <buse@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <vector>
+
+#include "veins/veins.h"
+
+namespace veins {
+
+class Obstacle;
+
+/**
+ * Fast grid-based spatial datastructure to find obstacles (geometric shapes) in a bounding box.
+ *
+ * Stores bounding boxes for a set of obstacles and allows searching for them via another bounding box.
+ *
+ * Only considers a 2-dimensional plane (x and y coordinates).
+ *
+ * In principle, any kind (or implementation) of a obstacle/shape/polygon is possible.
+ * There only has to be a function to derive a bounding box for a given obstacle.
+ * Obstacle instances are stored as pointers, so the lifetime of the obstacle instances is not managed by this class.
+ */
+class VEINS_API BBoxLookup {
+public:
+    struct Point {
+        double x;
+        double y;
+    };
+    // array of stucts approach
+    // cache line size: 64byte = 8 x 8-byte double = 2 bboxes per line
+    // bbox coordinates are inherently local, if i check x1, i likely also check the other
+    struct Box {
+        Point p1;
+        Point p2;
+    };
+    struct BBoxCell {
+        size_t index; /**< index of the first element of this cell in bboxes */
+        size_t count; /**< number of elements in this cell; index + number = index of last element */
+    };
+
+    BBoxLookup() = default;
+    BBoxLookup(const std::vector<Obstacle*>& obstacles, std::function<BBoxLookup::Box(Obstacle*)> makeBBox, double scenarioX, double scenarioY, int cellSize = 250);
+
+    /**
+     * Return all obstacles which have their bounding box touched by the transmission from sender to receiver.
+     *
+     * The obstacles itself may not actually overlap with transmission (false positives are possible).
+     */
+    std::vector<Obstacle*> findOverlapping(Point sender, Point receiver) const;
+
+private:
+    // NOTE: obstacles may occur multiple times in bboxes/obstacleLookup (if they are in multiple cells)
+    std::vector<Box> bboxes; /**< ALL bboxes in one chunck of contiguos memory, ordered by cells */
+    std::vector<Obstacle*> obstacleLookup; /**< bboxes[i] belongs to instance in obstacleLookup[i] */
+    std::vector<BBoxCell> bboxCells; /**< flattened matrix of X * Y BBoxCell instances */
+    int cellSize = 0;
+    size_t numCols = 0; /**< X BBoxCell instances in a row */
+    size_t numRows = 0; /**< Y BBoxCell instances in a column */
+};
+
+} // namespace veins


### PR DESCRIPTION
This PR replaces the internal bounding box check of the obstacle shadowing with a much more efficient one, leading to performance improvements of >10x (for scenarios with lots of obstacles).
E.g., in the Paderborn scenario (>50.000 obstacles), around 500 vehicles can be simulated in real time on an i7-7700K, compared to less then 50 with the old code.

Bounding box checks are extracted into the `BBoxLookup` helper class. This class maintains a dense and cache-friendly store of bounding boxes for all obstacles. To find relevant obstacles for a given communication (sender -> receiver), a ray-cast against the bounding boxes of obstacles close to the communication ray is performed. This closeness is modeled via a tile-based layout (similar to the old code in `ObstacleControl`).

In addition, some improvements to the `Obstacle` class were made. This includes the use of simpler data structures (e.g., once-sorted vector instead of multiset) and the removal of computations involving the creation of `Coord` instances in tight loops (`Coord` inherits from `omnetpp::cObject` and thus gets registered/deregistered on construction/destruction, causing measurable overhead).