### PR TITLE
Make Signal::getSpectrum return const ref.

### DIFF
--- a/src/veins/base/toolbox/Signal.cc
+++ b/src/veins/base/toolbox/Signal.cc
@@ -58,7 +58,7 @@ Signal::Signal(Spectrum spec, simtime_t start, simtime_t dur)
 {
 }
 
-Spectrum Signal::getSpectrum() const
+const Spectrum& Signal::getSpectrum() const
 {
     return spectrum;
 }

--- a/src/veins/base/toolbox/Signal.h
+++ b/src/veins/base/toolbox/Signal.h
@@ -62,7 +62,7 @@ public:
     /**
      * Get the Spectrum this Signal is defined on.
      */
-    Spectrum getSpectrum() const;
+    const Spectrum& getSpectrum() const;
 
     /**
      * @name Element access


### PR DESCRIPTION
Return a const ref instead of a copy. Does not hurt semantics at all.

This removes some unnecessary copying of instances of the `Spectrum` class, which show up in valgrind even in release mode.