### PR TITLE
Phy header definition

### DIFF
--- a/src/veins/base/phyLayer/BasePhyLayer.cc
+++ b/src/veins/base/phyLayer/BasePhyLayer.cc
@@ -543,6 +543,7 @@ unique_ptr<AirFrame> BasePhyLayer::encapsMsg(cPacket* macPkt)
     frame->setProtocolId(myProtocolId());
     frame->setId(world->getUniqueAirFrameId());
     frame->setChannel(radio->getCurrentChannel());
+    frame->setBitLength(0); // as the PHY might mix multiple different encoding rates (and things that might not be bits at all)
 
     frame->encapsulate(macPkt);
 

--- a/src/veins/modules/phy/Decider80211p.cc
+++ b/src/veins/modules/phy/Decider80211p.cc
@@ -170,14 +170,11 @@ DeciderResult* Decider80211p::checkIfSignalOk(AirFrame* frame)
 
 enum Decider80211p::PACKET_OK_RESULT Decider80211p::packetOk(double sinrMin, double snrMin, int lengthMPDU, double bitrate)
 {
-
-    // the lengthMPDU includes the PHY_SIGNAL_LENGTH + PHY_PSDU_HEADER + Payload, while the first is sent with PHY_HEADER_BANDWIDTH
-
     double packetOkSinr;
     double packetOkSnr;
 
     // compute success rate depending on mcs and bw
-    packetOkSinr = NistErrorRate::getChunkSuccessRate(bitrate, BANDWIDTH_11P, sinrMin, lengthMPDU);
+    packetOkSinr = NistErrorRate::getChunkSuccessRate(bitrate, BANDWIDTH_11P, sinrMin, PHY_HDR_SERVICE_LENGTH + lengthMPDU + PHY_TAIL_LENGTH);
 
     // check if header is broken
     double headerNoError = NistErrorRate::getChunkSuccessRate(PHY_HDR_BITRATE, BANDWIDTH_11P, sinrMin, PHY_HDR_PLCPSIGNAL_LENGTH);
@@ -186,7 +183,7 @@ enum Decider80211p::PACKET_OK_RESULT Decider80211p::packetOk(double sinrMin, dou
     // compute PER also for SNR only
     if (collectCollisionStats) {
 
-        packetOkSnr = NistErrorRate::getChunkSuccessRate(bitrate, BANDWIDTH_11P, snrMin, lengthMPDU);
+        packetOkSnr = NistErrorRate::getChunkSuccessRate(bitrate, BANDWIDTH_11P, snrMin, PHY_HDR_SERVICE_LENGTH + lengthMPDU + PHY_TAIL_LENGTH);
         headerNoErrorSnr = NistErrorRate::getChunkSuccessRate(PHY_HDR_BITRATE, BANDWIDTH_11P, snrMin, PHY_HDR_PLCPSIGNAL_LENGTH);
 
         // the probability of correct reception without considering the interference

--- a/src/veins/modules/utility/Consts80211p.h
+++ b/src/veins/modules/utility/Consts80211p.h
@@ -49,11 +49,17 @@ const uint32_t N_DBPS_80211P[] = {24, 36, 48, 72, 96, 144, 192, 216};
  */
 const double T_SYM_80211P = 8e-6;
 
-/** @brief Length of PHY HEADER
+/** @brief Length (in bits) of SERVICE field in PHY HEADER
  *
  * as defined in 17.3.2 PLCP frame format in the IEEE 802.11-2007 standard
- * 40bit header + 6 bit tail */
-const int PHY_HDR_TOTAL_LENGTH = 46;
+ */
+const int PHY_HDR_SERVICE_LENGTH = 16;
+
+/** @brief Length (in bits) of Tail field in PHY PPDU
+ *
+ * as defined in 17.3.2 PLCP frame format in the IEEE 802.11-2007 standard
+ */
+const int PHY_TAIL_LENGTH = 6;
 
 /** @brief Duration of the PLCP Preamble
  *
@@ -72,11 +78,6 @@ const double PHY_HDR_PLCPSIGNAL_DURATION = 8e-6;
  * as defined in Figure 17.1 PPDU frame format in the IEEE 802.11-2007 standard
  */
 const int PHY_HDR_PLCPSIGNAL_LENGTH = 24;
-
-/** @brief Lenght of the PhyHeader sent with normal bitrate
- *
- */
-const int PHY_HDR_PSDU_HEADER_LENGTH = PHY_HDR_TOTAL_LENGTH - PHY_HDR_PLCPSIGNAL_LENGTH;
 
 /** @brief Bitrate of the PLCP Signal
  *


### PR DESCRIPTION
The commit 2c3ff807020947cceee818fb650c3605c083f7bc removes the complete header definition of the phy, which is wrong according to the IEEE 802.11-2016 standard.
The header length is supposed to be 16 bit + 6 bit = 22 bit which gets fixed by this commit.