### PR TITLE
Introduce parameter connectionManagerName for Nic80211p and throws cR…

### DIFF
--- a/src/veins/base/connectionManager/ChannelAccess.cc
+++ b/src/veins/base/connectionManager/ChannelAccess.cc
@@ -43,7 +43,7 @@ BaseConnectionManager* ChannelAccess::getConnectionManager(cModule* nic)
         return dynamic_cast<BaseConnectionManager*>(ccModule);
     }
     else {
-        return FindModule<BaseConnectionManager*>::findGlobalModule();
+        throw cRuntimeError("Variable connectionManagerName must be specified");
     }
 }
 

--- a/src/veins/modules/nic/Nic80211p.ned
+++ b/src/veins/modules/nic/Nic80211p.ned
@@ -34,6 +34,8 @@ import org.car2x.veins.modules.mac.ieee80211p.Mac1609_4;
 //
 module Nic80211p like INic80211p
 {
+    parameters:
+        string connectionManagerName = default("connectionManager");
     gates:
         input upperLayerIn; // to upper layers
         output upperLayerOut; // from upper layers


### PR DESCRIPTION
Introduce parameter connectionManagerName for Nic80211p and throws cRuntimeError if value is not specified.