### PR TITLE
Fix: number of cells in BBoxLookup.

### DIFF
--- a/src/veins/modules/utility/BBoxLookup.cc
+++ b/src/veins/modules/utility/BBoxLookup.cc
@@ -93,8 +93,8 @@ BBoxLookup::BBoxLookup(const std::vector<Obstacle*>& obstacles, std::function<BB
     , obstacleLookup()
     , bboxCells()
     , cellSize(cellSize)
-    , numCols(std::ceil(scenarioX / cellSize))
-    , numRows(std::ceil(scenarioY / cellSize))
+    , numCols(std::floor(scenarioX / cellSize) + 1)
+    , numRows(std::floor(scenarioY / cellSize) + 1)
 {
     // phase 1: build unordered collection of cells
     // initialize proto-cells (cells in non-contiguos memory)


### PR DESCRIPTION
Ther was an off-by-one error if the scenario size is exactly divisble by the cell size.
Then the number of cells would be one to little.
This results in SIGSEV if there was an obstacle touching the secenario border.