### PR TITLE
Add option to configure traci port via env variable.

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -249,15 +249,7 @@ void TraCIScenarioManager::initialize(int stage)
     penetrationRate = par("penetrationRate").doubleValue();
     ignoreGuiCommands = par("ignoreGuiCommands");
     host = par("host").stdstringValue();
-    port = par("port");
-    if (port == -1) {
-        // cascaded search for externally configured traci port
-        const char* env_port = std::getenv("VEINS_TRACI_PORT");
-        if (env_port == nullptr) {
-            error("TraCI Port autoconfiguration failed, set `port` != -1 in omnetpp.ini or provide VEINS_TRACI_PORT environment variable.");
-        }
-        port = std::atoi(env_port);
-    }
+    port = autodetectTraCIPort();
     autoShutdown = par("autoShutdown");
 
     annotations = AnnotationManagerAccess().getIfExists();
@@ -1096,4 +1088,21 @@ void TraCIScenarioManager::processSubcriptionResult(TraCIBuffer& buf)
     else {
         error("Received unhandled subscription result");
     }
+}
+
+int TraCIScenarioManager::autodetectTraCIPort() const
+{
+    int port = par("port");
+    if (port != -1) {
+        return port;
+    }
+
+    // cascaded search for externally configured traci port
+    const char* env_port = std::getenv("VEINS_TRACI_PORT");
+    if (env_port == nullptr) {
+        throw cRuntimeError("TraCI Port autoconfiguration failed, set `port` != -1 in omnetpp.ini or provide VEINS_TRACI_PORT environment variable.");
+    }
+    port = std::atoi(env_port);
+
+    return port;
 }

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <stdexcept>
 #include <iterator>
+#include <cstdlib>
 
 #include "veins/modules/mobility/traci/TraCIScenarioManager.h"
 #include "veins/base/connectionManager/ChannelAccess.h"
@@ -249,6 +250,15 @@ void TraCIScenarioManager::initialize(int stage)
     ignoreGuiCommands = par("ignoreGuiCommands");
     host = par("host").stdstringValue();
     port = par("port");
+    if (port == -1) {
+        // cascaded search for externally configured traci port
+        const char* env_port = std::getenv("VEINS_TRACI_PORT");
+        if (env_port == nullptr) {
+            error("TraCI Port autoconfiguration failed, set `port` != -1 in omnetpp.ini or provide VEINS_TRACI_PORT environment variable.");
+        }
+        port = std::atoi(env_port);
+    }
+    ASSERT(port > 0 && port < 65536);
     autoShutdown = par("autoShutdown");
 
     annotations = AnnotationManagerAccess().getIfExists();

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -258,7 +258,6 @@ void TraCIScenarioManager::initialize(int stage)
         }
         port = std::atoi(env_port);
     }
-    ASSERT(port > 0 && port < 65536);
     autoShutdown = par("autoShutdown");
 
     annotations = AnnotationManagerAccess().getIfExists();

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -249,7 +249,10 @@ void TraCIScenarioManager::initialize(int stage)
     penetrationRate = par("penetrationRate").doubleValue();
     ignoreGuiCommands = par("ignoreGuiCommands");
     host = par("host").stdstringValue();
-    port = autodetectTraCIPort();
+    port = getPortNumber();
+    if (port == -1) {
+        throw cRuntimeError("TraCI Port autoconfiguration failed, set `port` != -1 in omnetpp.ini or provide VEINS_TRACI_PORT environment variable.");
+    }
     autoShutdown = par("autoShutdown");
 
     annotations = AnnotationManagerAccess().getIfExists();
@@ -1090,19 +1093,18 @@ void TraCIScenarioManager::processSubcriptionResult(TraCIBuffer& buf)
     }
 }
 
-int TraCIScenarioManager::autodetectTraCIPort() const
+int TraCIScenarioManager::getPortNumber() const
 {
     int port = par("port");
     if (port != -1) {
         return port;
     }
 
-    // cascaded search for externally configured traci port
+    // search for externally configured traci port
     const char* env_port = std::getenv("VEINS_TRACI_PORT");
-    if (env_port == nullptr) {
-        throw cRuntimeError("TraCI Port autoconfiguration failed, set `port` != -1 in omnetpp.ini or provide VEINS_TRACI_PORT environment variable.");
+    if (env_port != nullptr) {
+        port = std::atoi(env_port);
     }
-    port = std::atoi(env_port);
 
     return port;
 }

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -192,6 +192,8 @@ protected:
      * transforms a list of mappings of an omnetpp.ini parameter in a list
      */
     TypeMapping parseMappings(std::string parameter, std::string parameterName, bool allowEmpty = false);
+
+    virtual int autodetectTraCIPort() const;
 };
 
 class VEINS_API TraCIScenarioManagerAccess {

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -193,7 +193,7 @@ protected:
      */
     TypeMapping parseMappings(std::string parameter, std::string parameterName, bool allowEmpty = false);
 
-    virtual int autodetectTraCIPort() const;
+    virtual int getPortNumber() const;
 };
 
 class VEINS_API TraCIScenarioManagerAccess {

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.cc
@@ -113,21 +113,15 @@ void TraCIScenarioManagerForker::killServer()
     }
 }
 
-int TraCIScenarioManagerForker::autodetectTraCIPort() const
+int TraCIScenarioManagerForker::getPortNumber() const
 {
-    int port = par("port");
+    int port = TraCIScenarioManager::getPortNumber();
     if (port != -1) {
         return port;
     }
 
-    // cascaded search for externally configured traci port
-    const char* env_port = std::getenv("VEINS_TRACI_PORT");
-    if (env_port != nullptr) {
-        port = std::atoi(env_port);
-        return port;
-    }
+    // find a free port for the forker if port is still -1
 
-    // cascade into finding a free port for the forker
     if (initsocketlibonce() != 0) throw cRuntimeError("Could not init socketlib");
 
     SOCKET sock = ::socket(AF_INET, SOCK_STREAM, 0);

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.h
@@ -59,6 +59,7 @@ protected:
 
     virtual void startServer();
     virtual void killServer();
+    int autodetectTraCIPort() const override;
 };
 
 class VEINS_API TraCIScenarioManagerForkerAccess {

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.h
@@ -59,7 +59,7 @@ protected:
 
     virtual void startServer();
     virtual void killServer();
-    int autodetectTraCIPort() const override;
+    int getPortNumber() const override;
 };
 
 class VEINS_API TraCIScenarioManagerForkerAccess {


### PR DESCRIPTION
TraCIScenarioManager can now read the tracie port from an env variable.
The name of the variable is VEINS_TRACI_PORT.
This is only triggered if the port parameter is set to -1.
If this is the case, but VEINS_TRACI_PORT is not set, veins dies.