### PR TITLE
Avoid use after free

### DIFF
--- a/src/veins/modules/utility/SignalManager.h
+++ b/src/veins/modules/utility/SignalManager.h
@@ -50,7 +50,9 @@ public:
 
     ~SignalCallbackListener()
     {
-        receptor->unsubscribe(signal, this);
+        if (getSubscribeCount() > 0) {
+            receptor->unsubscribe(signal, this);
+        }
     }
 
     void receiveSignal(cComponent* source, simsignal_t signalID, Payload p, cObject* details) override


### PR DESCRIPTION
Modules in the same scope will get freed in an arbitrary order.
Subscriptions between such modules might try to unsubscribe from an
already deleted module. During deletion of the subscribed module, this
relation has already been cleaned up, so unsubscribing is unnecessary in
this case.