### PR TITLE
Add traci calls for a vehicle type's maximum speed

### DIFF
--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -235,6 +235,11 @@ std::list<std::string> TraCICommandInterface::getVehicleTypeIds()
     return genericGetStringList(CMD_GET_VEHICLETYPE_VARIABLE, "", ID_LIST, RESPONSE_GET_VEHICLETYPE_VARIABLE);
 }
 
+double TraCICommandInterface::getVehicleTypeMaxSpeed(std::string typeId)
+{
+    return genericGetDouble(CMD_GET_VEHICLETYPE_VARIABLE, typeId, VAR_MAXSPEED, RESPONSE_GET_VEHICLETYPE_VARIABLE);
+}
+
 void TraCICommandInterface::setVehicleTypeMaxSpeed(std::string typeId, double maxSpeed)
 {
     genericSetDouble(CMD_SET_VEHICLETYPE_VARIABLE, typeId, VAR_MAXSPEED, maxSpeed);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -1330,6 +1330,13 @@ double TraCICommandInterface::genericGetDouble(uint8_t commandId, std::string ob
     return res;
 }
 
+void TraCICommandInterface::genericSetDouble(uint8_t commandId, std::string objectId, uint8_t variableId, double value)
+{
+    uint8_t variableType = TYPE_DOUBLE;
+    TraCIBuffer buf = connection.query(commandId, TraCIBuffer() << variableId << objectId << variableType << value);
+    ASSERT(buf.eof());
+}
+
 simtime_t TraCICommandInterface::genericGetTime(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId, TraCIConnection::Result* result)
 {
     uint8_t resultTypeId = getTimeType();

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -235,6 +235,11 @@ std::list<std::string> TraCICommandInterface::getVehicleTypeIds()
     return genericGetStringList(CMD_GET_VEHICLETYPE_VARIABLE, "", ID_LIST, RESPONSE_GET_VEHICLETYPE_VARIABLE);
 }
 
+void TraCICommandInterface::setVehicleTypeMaxSpeed(std::string typeId, double maxSpeed)
+{
+    genericSetDouble(CMD_SET_VEHICLETYPE_VARIABLE, typeId, VAR_MAXSPEED, maxSpeed);
+}
+
 std::list<std::string> TraCICommandInterface::getRouteIds()
 {
     return genericGetStringList(CMD_GET_ROUTE_VARIABLE, "", ID_LIST, RESPONSE_GET_ROUTE_VARIABLE);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -516,6 +516,7 @@ private:
     std::string genericGetString(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId, TraCIConnection::Result* result = nullptr);
     Coord genericGetCoord(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId, TraCIConnection::Result* result = nullptr);
     double genericGetDouble(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId, TraCIConnection::Result* result = nullptr);
+    void genericSetDouble(uint8_t commandId, std::string objectId, uint8_t variableId, double value);
     simtime_t genericGetTime(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId, TraCIConnection::Result* result = nullptr);
     int32_t genericGetInt(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId, TraCIConnection::Result* result = nullptr);
     std::list<std::string> genericGetStringList(uint8_t commandId, std::string objectId, uint8_t variableId, uint8_t responseId, TraCIConnection::Result* result = nullptr);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -465,6 +465,7 @@ public:
 
     // Vehicletype methods
     std::list<std::string> getVehicleTypeIds();
+    void setVehicleTypeMaxSpeed(std::string typeId, double maxSpeed);
 
     // GuiView methods
     std::list<std::string> getGuiViewIds();

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -465,6 +465,7 @@ public:
 
     // Vehicletype methods
     std::list<std::string> getVehicleTypeIds();
+    double getVehicleTypeMaxSpeed(std::string typeId);
     void setVehicleTypeMaxSpeed(std::string typeId, double maxSpeed);
 
     // GuiView methods

--- a/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
+++ b/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
@@ -100,7 +100,7 @@ sim-time-limit = 100s
 ##########################################################
 
 *.node[*].applType = "org.car2x.veins.subprojects.veins_testsims.traci.TraCITestApp"
-*.node[0].appl.testNumber = ${0..79}
+*.node[0].appl.testNumber = ${0..80}
 *.node[*].appl.testNumber = -1
 
 ##########################################################

--- a/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
+++ b/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
@@ -100,7 +100,7 @@ sim-time-limit = 100s
 ##########################################################
 
 *.node[*].applType = "org.car2x.veins.subprojects.veins_testsims.traci.TraCITestApp"
-*.node[0].appl.testNumber = ${0..78}
+*.node[0].appl.testNumber = ${0..79}
 *.node[*].appl.testNumber = -1
 
 ##########################################################

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -208,8 +208,13 @@ void TraCITestApp::handlePositionUpdate()
     if (testNumber == testCounter++) {
         if (t == 1) {
             assertEqual("(TraCICommandInterface::getVehicleTypeMaxSpeed speed is correct)", traci->getVehicleTypeMaxSpeed("vtype0"), 70);
+        }
+    }
+
+    if (testNumber == testCounter++) {
+        if (t == 1) {
             traci->setVehicleTypeMaxSpeed("vtype0", 60);
-            assertEqual("(TraCICommandInterface::getVehicleTypeMaxSpeed) changed speed is correct", traci->getVehicleTypeMaxSpeed("vtype0"), 60);
+            assertEqual("(TraCICommandInterface::setVehicleTypeMaxSpeed) changed speed is correct", traci->getVehicleTypeMaxSpeed("vtype0"), 60);
             // change back to original value
             traci->setVehicleTypeMaxSpeed("vtype0", 70);
         }

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -207,6 +207,16 @@ void TraCITestApp::handlePositionUpdate()
 
     if (testNumber == testCounter++) {
         if (t == 1) {
+            assertEqual("(TraCICommandInterface::getVehicleTypeMaxSpeed speed is correct)", traci->getVehicleTypeMaxSpeed("vtype0"), 70);
+            traci->setVehicleTypeMaxSpeed("vtype0", 60);
+            assertEqual("(TraCICommandInterface::getVehicleTypeMaxSpeed) changed speed is correct", traci->getVehicleTypeMaxSpeed("vtype0"), 60);
+            // change back to original value
+            traci->setVehicleTypeMaxSpeed("vtype0", 70);
+        }
+    }
+
+    if (testNumber == testCounter++) {
+        if (t == 1) {
             std::list<std::string> o = traci->getTrafficlightIds();
             assertEqual("(TraCICommandInterface::getTrafficlightIds) number is 1", size_t(1), o.size());
             assertEqual("(TraCICommandInterface::getTrafficlightIds) id is correct", "10", *o.begin());

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -207,7 +207,7 @@ void TraCITestApp::handlePositionUpdate()
 
     if (testNumber == testCounter++) {
         if (t == 1) {
-            assertEqual("(TraCICommandInterface::getVehicleTypeMaxSpeed speed is correct)", traci->getVehicleTypeMaxSpeed("vtype0"), 70);
+            assertEqual("(TraCICommandInterface::getVehicleTypeMaxSpeed) speed is correct", traci->getVehicleTypeMaxSpeed("vtype0"), 70);
         }
     }
 

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -217,6 +217,7 @@ void TraCITestApp::handlePositionUpdate()
             assertEqual("(TraCICommandInterface::setVehicleTypeMaxSpeed) changed speed is correct", traci->getVehicleTypeMaxSpeed("vtype0"), 60);
             // change back to original value
             traci->setVehicleTypeMaxSpeed("vtype0", 70);
+            assertEqual("(TraCICommandInterface::setVehicleTypeMaxSpeed) changed speed is correct", traci->getVehicleTypeMaxSpeed("vtype0"), 70);
         }
     }
 


### PR DESCRIPTION
I tested the new methods with the integrated veins_testsims (SUMO 0.30.0, 0.32.0, 1.0.0, 1.0.1, 1.1.0, 1.2.0, 1.3.1) as well as some custom simulation I am currently working on. I used OMNET 5.4.1.  It does not change anything in the API.
