### PR TITLE
Add some mac layer statistics

### DIFF
--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -37,6 +37,8 @@ Define_Module(veins::Mac1609_4);
 
 const simsignal_t Mac1609_4::sigChannelBusy = registerSignal("org_car2x_veins_modules_mac_sigChannelBusy");
 const simsignal_t Mac1609_4::sigCollision = registerSignal("org_car2x_veins_modules_mac_sigCollision");
+const simsignal_t Mac1609_4::sigSentPacket = registerSignal("org_car2x_veins_modules_mac_sigSentPacket");
+const simsignal_t Mac1609_4::sigSentAck = registerSignal("org_car2x_veins_modules_mac_sigSentAck");
 
 void Mac1609_4::initialize(int stage)
 {
@@ -472,9 +474,11 @@ void Mac1609_4::sendFrame(Mac80211Pkt* frame, simtime_t delay, Channel channelNr
 
     if (dynamic_cast<Mac80211Ack*>(frame)) {
         statsSentAcks += 1;
+        emit(sigSentAck, true);
     }
     else {
         statsSentPackets += 1;
+        emit(sigSentPacket, true);
     }
 }
 

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -72,6 +72,10 @@ public:
     static const simsignal_t sigChannelBusy;
     // tell to anybody which is interested when a collision occurred
     static const simsignal_t sigCollision;
+    // tell to anybody which is interested when a packet was sent
+    static const simsignal_t sigSentPacket;
+    // tell to anybody which is interested when a acknowledgement was sent
+    static const simsignal_t sigSentAck;
 
     // Access categories in increasing order of priority (see IEEE Std 802.11-2012, Table 9-1)
     enum t_access_category {

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
@@ -74,5 +74,11 @@ simple Mac1609_4 extends BaseMacLayer
         // signal informing interested application about a collision
         @signal[org_car2x_veins_modules_mac_sigCollision](type=bool);
         @statistic[collisions](source=org_car2x_veins_modules_mac_sigCollision; record=count, vector?);
+        // signal informing interested application about a sent packet
+        @signal[org_car2x_veins_modules_mac_sigSentPacket](type=bool);
+        @statistic[sentPackets](source=org_car2x_veins_modules_mac_sigSentPacket; record=count, vector?);
+        // signal informing interested application about a sent ackknowledgement
+        @signal[org_car2x_veins_modules_mac_sigSentAck](type=bool);
+        @statistic[sentAcks](source=org_car2x_veins_modules_mac_sigSentAck; record=count, vector?);
 
 }

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
@@ -70,7 +70,9 @@ simple Mac1609_4 extends BaseMacLayer
 
         // signal informing interested application about channel busy state
         @signal[org_car2x_veins_modules_mac_sigChannelBusy](type=bool);
+        @statistic[channelBusy](source=org_car2x_veins_modules_mac_sigChannelBusy; record=timeavg, vector?);
         // signal informing interested application about a collision
         @signal[org_car2x_veins_modules_mac_sigCollision](type=bool);
+        @statistic[collisions](source=org_car2x_veins_modules_mac_sigCollision; record=count, vector?);
 
 }


### PR DESCRIPTION
Following the regular approach of using signals, this PR adds some statistic recording to the (unicast) mac layer. I compiled and tested this with OMNET 5.4.1. It does not change anything in the API or in regard to SUMO.