### PR TITLE
Handle pointer properly on destruction

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -65,8 +65,14 @@ TraCIScenarioManager::~TraCIScenarioManager()
     if (connection) {
         TraCIBuffer buf = connection->query(CMD_CLOSE, TraCIBuffer());
     }
-    cancelAndDelete(connectAndStartTrigger);
-    cancelAndDelete(executeOneTimestepTrigger);
+    if (connectAndStartTrigger) {
+        cancelAndDelete(connectAndStartTrigger);
+        connectAndStartTrigger = nullptr;
+    }
+    if (executeOneTimestepTrigger) {
+        cancelAndDelete(executeOneTimestepTrigger);
+        executeOneTimestepTrigger = nullptr;
+    }
 }
 
 namespace {


### PR DESCRIPTION
This PR cleans up the pointer to messages properly on module destruction (i.e., according to the manual). Compiled with OMNET 5.4.1. but should be independent from its version. It does not change anything in the API or in regard to SUMO.