### PR TITLE
WIP: Extends the statistic recording for emissions and fuel

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -34,6 +34,7 @@ Define_Module(veins::TraCIMobility);
 
 const simsignal_t TraCIMobility::parkingStateChangedSignal = registerSignal("org_car2x_veins_modules_mobility_parkingStateChanged");
 const simsignal_t TraCIMobility::currentCO2EmissionSignal = registerSignal("org_car2x_veins_modules_mobility_currentCO2Emission");
+const simsignal_t TraCIMobility::currentFuelConsumptionSignal = registerSignal("org_car2x_veins_modules_mobility_currentFuelConsumption");
 
 namespace {
 const double MY_INFINITY = (std::numeric_limits<double>::has_infinity ? std::numeric_limits<double>::infinity() : std::numeric_limits<double>::max());
@@ -217,6 +218,7 @@ void TraCIMobility::changePosition()
                 currentAccelerationVec.record(acceleration);
                 currentCO2EmissionVec.record(co2emission);
                 emit(currentCO2EmissionSignal, co2emission * updateInterval.dbl());
+                emit(currentFuelConsumptionSignal, fuelConsumption * updateInterval.dbl());
                 statistics.totalCO2Emission += co2emission * updateInterval.dbl();
             }
             last_speed = speed;

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -274,29 +274,29 @@ double TraCIMobility::calculateCO2emission(double v, double a) const
     // Calculate CO2 emission parameters according to:
     // Cappiello, A. and Chabini, I. and Nam, E.K. and Lue, A. and Abou Zeid, M., "A statistical model of vehicle emissions and fuel consumption," IEEE 5th International Conference on Intelligent Transportation Systems (IEEE ITSC), pp. 801-809, 2002
 
-    double A = 1000 * 0.1326; // W/m/s
-    double B = 1000 * 2.7384e-03; // W/(m/s)^2
-    double C = 1000 * 1.0843e-03; // W/(m/s)^3
-    double M = 1325.0; // kg
+    constexpr double A = 1000 * 0.1326; // W/m/s
+    constexpr double B = 1000 * 2.7384e-03; // W/(m/s)^2
+    constexpr double C = 1000 * 1.0843e-03; // W/(m/s)^3
+    constexpr double M = 1325.0; // kg
 
     // power in W
     double P_tract = A * v + B * v * v + C * v * v * v + M * a * v; // for sloped roads: +M*g*sin_theta*v
 
     /*
        // "Category 7 vehicle" (e.g. a '92 Suzuki Swift)
-       double alpha = 1.01;
-       double beta = 0.0162;
-       double delta = 1.90e-06;
-       double zeta = 0.252;
-       double alpha1 = 0.985;
+       constexpr double alpha = 1.01;
+       constexpr double beta = 0.0162;
+       constexpr double delta = 1.90e-06;
+       constexpr double zeta = 0.252;
+       constexpr double alpha1 = 0.985;
      */
 
     // "Category 9 vehicle" (e.g. a '94 Dodge Spirit)
-    double alpha = 1.11;
-    double beta = 0.0134;
-    double delta = 1.98e-06;
-    double zeta = 0.241;
-    double alpha1 = 0.973;
+    constexpr double alpha = 1.11;
+    constexpr double beta = 0.0134;
+    constexpr double delta = 1.98e-06;
+    constexpr double zeta = 0.241;
+    constexpr double alpha1 = 0.973;
 
     if (P_tract <= 0) return alpha1;
     return alpha + beta * v * 3.6 + delta * v * v * v * (3.6 * 3.6 * 3.6) + zeta * a * v;

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -213,6 +213,7 @@ void TraCIMobility::changePosition()
             if (last_speed != -1) {
                 double acceleration = (speed - last_speed) / updateInterval;
                 double co2emission = calculateCO2emission(speed, acceleration);
+                double fuelConsumption = calculateFuelConsumption(speed, acceleration);
                 currentAccelerationVec.record(acceleration);
                 currentCO2EmissionVec.record(co2emission);
                 emit(currentCO2EmissionSignal, co2emission * updateInterval.dbl());

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -33,6 +33,7 @@ using veins::TraCIMobility;
 Define_Module(veins::TraCIMobility);
 
 const simsignal_t TraCIMobility::parkingStateChangedSignal = registerSignal("org_car2x_veins_modules_mobility_parkingStateChanged");
+const simsignal_t TraCIMobility::currentCO2EmissionSignal = registerSignal("org_car2x_veins_modules_mobility_currentCO2Emission");
 
 namespace {
 const double MY_INFINITY = (std::numeric_limits<double>::has_infinity ? std::numeric_limits<double>::infinity() : std::numeric_limits<double>::max());
@@ -214,6 +215,7 @@ void TraCIMobility::changePosition()
                 double co2emission = calculateCO2emission(speed, acceleration);
                 currentAccelerationVec.record(acceleration);
                 currentCO2EmissionVec.record(co2emission);
+                emit(currentCO2EmissionSignal, co2emission * updateInterval.dbl());
                 statistics.totalCO2Emission += co2emission * updateInterval.dbl();
             }
             last_speed = speed;

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -317,6 +317,23 @@ double TraCIMobility::calculateCO2emission(double v, double a) const
     return alpha + beta * ::ms_to_kmph(v) + delta * std::pow(::ms_to_kmph(v), 3) + zeta * a * v;
 }
 
+double TraCIMobility::calculateFuelConsumption(double v, double a) const
+{
+    // Calculate fuel consumption parameters according to:
+    // Cappiello, A. and Chabini, I. and Nam, E.K. and Lue, A. and Abou Zeid, M., "A statistical model of vehicle emissions and fuel consumption," IEEE 5th International Conference on Intelligent Transportation Systems (IEEE ITSC), pp. 801-809, 2002
+
+    // Table 1: calibrated parameters for the engine-out emissions module
+    constexpr double alpha = 0.365;
+    constexpr double beta = 0.00114;
+    constexpr double delta = 9.65e-07;
+    constexpr double zeta = 0.0943;
+    constexpr double alpha1 = 0.299;
+
+    // Eq 6 - please note: gamma was dropped
+    if (::calculatePTract(a, v) <= 0) return alpha1;
+    return alpha + beta * ::ms_to_kmph(v) + delta * std::pow(::ms_to_kmph(v), 3) + zeta * a * v;
+}
+
 Coord TraCIMobility::calculateHostPosition(const Coord& vehiclePos) const
 {
     Coord corPos;

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -84,6 +84,7 @@ void TraCIMobility::initialize(int stage)
         currentSpeedVec.setName("speed");
         currentAccelerationVec.setName("acceleration");
         currentCO2EmissionVec.setName("co2emission");
+        currentFuelConsumptionVec.setName("fuelconsumption");
 
         statistics.initialize();
         statistics.watch(*this);
@@ -219,6 +220,7 @@ void TraCIMobility::changePosition()
                 double fuelConsumption = calculateFuelConsumption(speed, acceleration);
                 currentAccelerationVec.record(acceleration);
                 currentCO2EmissionVec.record(co2emission);
+                currentFuelConsumptionVec.record(fuelConsumption);
                 emit(currentCO2EmissionSignal, co2emission * updateInterval.dbl());
                 emit(currentFuelConsumptionSignal, fuelConsumption * updateInterval.dbl());
                 statistics.totalCO2Emission += co2emission * updateInterval.dbl();

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -50,6 +50,7 @@ void TraCIMobility::Statistics::initialize()
     maxSpeed = -MY_INFINITY;
     totalDistance = 0;
     totalCO2Emission = 0;
+    totalFuelConsumption = 0;
 }
 
 void TraCIMobility::Statistics::watch(cSimpleModule&)
@@ -66,6 +67,7 @@ void TraCIMobility::Statistics::recordScalars(cSimpleModule& module)
     if (maxSpeed != -MY_INFINITY) module.recordScalar("maxSpeed", maxSpeed);
     module.recordScalar("totalDistance", totalDistance);
     module.recordScalar("totalCO2Emission", totalCO2Emission);
+    module.recordScalar("totalFuelConsumption", totalFuelConsumption);
 }
 
 void TraCIMobility::initialize(int stage)
@@ -220,6 +222,7 @@ void TraCIMobility::changePosition()
                 emit(currentCO2EmissionSignal, co2emission * updateInterval.dbl());
                 emit(currentFuelConsumptionSignal, fuelConsumption * updateInterval.dbl());
                 statistics.totalCO2Emission += co2emission * updateInterval.dbl();
+                statistics.totalFuelConsumption += fuelConsumption * updateInterval.dbl();
             }
             last_speed = speed;
         }

--- a/src/veins/modules/mobility/traci/TraCIMobility.h
+++ b/src/veins/modules/mobility/traci/TraCIMobility.h
@@ -75,6 +75,7 @@ public:
     };
 
     const static simsignal_t parkingStateChangedSignal;
+    const static simsignal_t currentCO2EmissionSignal;
 
     TraCIMobility()
         : BaseMobility()

--- a/src/veins/modules/mobility/traci/TraCIMobility.h
+++ b/src/veins/modules/mobility/traci/TraCIMobility.h
@@ -171,6 +171,7 @@ protected:
     cOutVector currentSpeedVec; /**< vector plotting speed */
     cOutVector currentAccelerationVec; /**< vector plotting acceleration */
     cOutVector currentCO2EmissionVec; /**< vector plotting current CO2 emission */
+    cOutVector currentFuelConsumptionVec; /**< vector plotting current fuel consumption */
 
     Statistics statistics; /**< everything statistics-related */
 

--- a/src/veins/modules/mobility/traci/TraCIMobility.h
+++ b/src/veins/modules/mobility/traci/TraCIMobility.h
@@ -68,6 +68,7 @@ public:
         double maxSpeed; /**< for statistics: maximum value of currentSpeed */
         double totalDistance; /**< for statistics: total distance travelled */
         double totalCO2Emission; /**< for statistics: total CO2 emission */
+        double totalFuelConsumption; /**< for statistics: total fuel consumption */
 
         void initialize();
         void watch(cSimpleModule& module);

--- a/src/veins/modules/mobility/traci/TraCIMobility.h
+++ b/src/veins/modules/mobility/traci/TraCIMobility.h
@@ -76,6 +76,7 @@ public:
 
     const static simsignal_t parkingStateChangedSignal;
     const static simsignal_t currentCO2EmissionSignal;
+    const static simsignal_t currentFuelConsumptionSignal;
 
     TraCIMobility()
         : BaseMobility()

--- a/src/veins/modules/mobility/traci/TraCIMobility.h
+++ b/src/veins/modules/mobility/traci/TraCIMobility.h
@@ -205,6 +205,14 @@ protected:
     double calculateCO2emission(double v, double a) const;
 
     /**
+     * Returns the amount of consumed fuel in ml/second, calculated for an average Car
+     * @param v speed in m/s
+     * @param a acceleration in m/s^2
+     * @returns consumption in g/s
+     */
+    double calculateFuelConsumption(double v, double a) const;
+
+    /**
      * Calculates where the OMNeT++ module position of this car should be, given its front bumper position
      */
     Coord calculateHostPosition(const Coord& vehiclePos) const;

--- a/src/veins/modules/mobility/traci/TraCIMobility.ned
+++ b/src/veins/modules/mobility/traci/TraCIMobility.ned
@@ -43,6 +43,7 @@ simple TraCIMobility extends BaseMobility
         @class(veins::TraCIMobility);
         @signal[org_car2x_veins_modules_mobility_parkingStateChanged](type=veins::TraCIMobility);
         @signal[org_car2x_veins_modules_mobility_currentCO2Emission](type=double);
+        @signal[org_car2x_veins_modules_mobility_currentFuelConsumption](type=double);
         @display("i=block/cogwheel");
         double hostPositionOffset @unit("m") = default(0.0m);  // shift OMNeT++ module this far from front of the car
         bool setHostSpeed = default(false);  // whether to update the speed of the host (along with its position)

--- a/src/veins/modules/mobility/traci/TraCIMobility.ned
+++ b/src/veins/modules/mobility/traci/TraCIMobility.ned
@@ -42,6 +42,7 @@ simple TraCIMobility extends BaseMobility
     parameters:
         @class(veins::TraCIMobility);
         @signal[org_car2x_veins_modules_mobility_parkingStateChanged](type=veins::TraCIMobility);
+        @signal[org_car2x_veins_modules_mobility_currentCO2Emission](type=double);
         @display("i=block/cogwheel");
         double hostPositionOffset @unit("m") = default(0.0m);  // shift OMNeT++ module this far from front of the car
         bool setHostSpeed = default(false);  // whether to update the speed of the host (along with its position)


### PR DESCRIPTION
This PR extends the existing CO2 emission calculation by adding a corresponding signal. Furthermore, it uses the same model 

// Cappiello, A. and Chabini, I. and Nam, E.K. and Lue, A. and Abou Zeid, M., "A statistical model of vehicle emissions and fuel consumption," IEEE 5th International Conference on Intelligent Transportation Systems (IEEE ITSC), pp. 801-809, 2002

to calculate the fuel consumption. I tested and compiled this with OMNET 5.4.1. It does not change anything in the API or in regard to SUMO.