### PR TITLE
Fix INET visualization when using veins_inet

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -46,6 +46,7 @@ using veins::TraCITrafficLightInterface;
 Define_Module(veins::TraCIScenarioManager);
 
 const simsignal_t TraCIScenarioManager::traciInitializedSignal = registerSignal("org_car2x_veins_modules_mobility_traciInitialized");
+const simsignal_t TraCIScenarioManager::traciModulePreInitSignal = registerSignal("org_car2x_veins_modules_mobility_traciModulePreInit");
 const simsignal_t TraCIScenarioManager::traciModuleAddedSignal = registerSignal("org_car2x_veins_modules_mobility_traciModuleAdded");
 const simsignal_t TraCIScenarioManager::traciModuleRemovedSignal = registerSignal("org_car2x_veins_modules_mobility_traciModuleRemoved");
 const simsignal_t TraCIScenarioManager::traciTimestepBeginSignal = registerSignal("org_car2x_veins_modules_mobility_traciTimestepBegin");
@@ -517,6 +518,8 @@ void TraCIScenarioManager::addModule(std::string nodeId, std::string type, std::
     mod->scheduleStart(simTime() + updateInterval);
 
     preInitializeModule(mod, nodeId, position, road_id, speed, heading, signals);
+
+    emit(traciModulePreInitSignal, mod);
 
     mod->callInitialize();
     hosts[nodeId] = mod;

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -67,6 +67,7 @@ class MobileHostObstacle;
 class VEINS_API TraCIScenarioManager : public cSimpleModule {
 public:
     static const simsignal_t traciInitializedSignal;
+    static const simsignal_t traciModulePreInitSignal;
     static const simsignal_t traciModuleAddedSignal;
     static const simsignal_t traciModuleRemovedSignal;
     static const simsignal_t traciTimestepBeginSignal;

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.ned
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.ned
@@ -39,6 +39,7 @@ simple TraCIScenarioManager
     parameters:
         @display("i=block/network2");
         @signal[org_car2x_veins_modules_mobility_traciInitialized](type=bool);
+        @signal[org_car2x_veins_modules_mobility_traciModulePreInit](type=cModule);
         @signal[org_car2x_veins_modules_mobility_traciModuleAdded](type=cModule);
         @signal[org_car2x_veins_modules_mobility_traciModuleRemoved](type=cModule);
         @signal[org_car2x_veins_modules_mobility_traciTimestepBegin](type=simtime_t);

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
@@ -78,13 +78,5 @@ void VeinsInetManager::receiveSignal(cComponent* source, simsignal_t signalID, c
         notification->module = module;
 
         root->emit(POST_MODEL_CHANGE, notification, NULL);
-    } else if (signalID == TraCIScenarioManager::traciModuleRemovedSignal) {
-        // Note that the TraCIScenarioManager sends the "removed"
-        // signal _before_ the actual removal takes place.
-
-        auto* notification = new inet::cPreModuleDeleteNotification();
-        notification->module = module;
-
-        root->emit(PRE_MODEL_CHANGE, notification, NULL);
     }
 }

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
@@ -42,7 +42,20 @@ void VeinsInetManager::initialize(int stage) {
     if (stage != 1)
         return;
 
-    this->subscribe(TraCIScenarioManager::traciModulePreInitSignal, this);
+#if INET_VERSION >= 0x0402
+    signalManager.subscribeCallback(this, TraCIScenarioManager::traciModulePreInitSignal, [this](SignalPayload<cObject*> payload) {
+        cModule* module = dynamic_cast<cModule*>(payload.p);
+        ASSERT(module);
+
+        // The INET visualizer listens to model change notifications on the
+        // network object by default. We assume this is our parent.
+        cModule *root = getParentModule();
+
+        auto* notification = new inet::cPreModuleInitNotification();
+        notification->module = module;
+        root->emit(POST_MODEL_CHANGE, notification, NULL);
+    });
+#endif
 }
 
 void VeinsInetManager::preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, Heading heading, VehicleSignalSet signals)
@@ -60,23 +73,5 @@ void VeinsInetManager::updateModulePosition(cModule* mod, const Coord& p, const 
     auto mobilityModules = getSubmodulesOfType<VeinsInetMobility>(mod);
     for (auto inetmm : mobilityModules) {
         inetmm->nextPosition(inet::Coord(p.x, p.y), edge, speed, heading.getRad());
-    }
-}
-
-
-void VeinsInetManager::receiveSignal(cComponent* source, simsignal_t signalID, cObject* obj, cObject* details)
-{
-    cModule* module = dynamic_cast<cModule*>(obj);
-    ASSERT(module);
-
-    // The INET visualizer listens to model change notifications on the
-    // network object by default. We assume this is our parent.
-    cModule *root = getParentModule();
-
-    if (signalID == TraCIScenarioManager::traciModulePreInitSignal) {
-        auto* notification = new inet::cPreModuleInitNotification();
-        notification->module = module;
-
-        root->emit(POST_MODEL_CHANGE, notification, NULL);
     }
 }

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
@@ -25,6 +25,7 @@
 #include "veins_inet/veins_inet.h"
 
 #include "veins/modules/mobility/traci/TraCIScenarioManagerLaunchd.h"
+#include "veins/modules/utility/SignalManager.h"
 
 namespace veins {
 
@@ -47,7 +48,7 @@ public:
     virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, Heading heading, VehicleSignalSet signals) override;
 
 protected:
-    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
+    SignalManager signalManager;
 };
 
 class VEINS_INET_API VeinsInetManagerAccess {

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
@@ -37,13 +37,17 @@ namespace veins {
  * @author Christoph Sommer
  *
  */
-class VEINS_INET_API VeinsInetManager : public TraCIScenarioManagerLaunchd {
+class VEINS_INET_API VeinsInetManager : public TraCIScenarioManagerLaunchd, public cListener {
 public:
     virtual ~VeinsInetManager();
+
+    void initialize(int stage) override;
+
     virtual void preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, Heading heading, VehicleSignalSet signals) override;
     virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, Heading heading, VehicleSignalSet signals) override;
 
 protected:
+    virtual void receiveSignal(cComponent *source, simsignal_t signalID, cObject *obj, cObject *details) override;
 };
 
 class VEINS_INET_API VeinsInetManagerAccess {

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
@@ -38,7 +38,7 @@ namespace veins {
  * @author Christoph Sommer
  *
  */
-class VEINS_INET_API VeinsInetManager : public TraCIScenarioManagerLaunchd, public cListener {
+class VEINS_INET_API VeinsInetManager : public TraCIScenarioManagerLaunchd {
 public:
     virtual ~VeinsInetManager();
 


### PR DESCRIPTION
When using the visualization capabilities of INET, the simulation model needs to indicate the addition/removal of nodes at runtime. Otherwise required visualization components are not created and the simulation crashes.

These events shall be emitted by the "visualizationSubjectModule" of the visualizer which usually is the root module of the simulation. This modifies the VeinsInetManager to make its parent module emit these events while also adding a required signal to the TraCIScenarioManager.

Note that the underlying model change signalling mechanism is already integrated into OMNeT++ (See cmodelchange.h), though some additional required events are defined by INET but are planned to be moved there as well.