### PR TITLE
Artificial frame dropping feature for Mac1609_4

### DIFF
--- a/src/veins/base/modules/BaseMacLayer.h
+++ b/src/veins/base/modules/BaseMacLayer.h
@@ -110,6 +110,15 @@ public:
         return myMacAddr;
     }
 
+    /**
+     * @brief Sets the MAC address of this MAC module.
+     */
+    void setMACAddress(LAddress::L2Type macAddr)
+    {
+        ASSERT(macAddr != LAddress::L2BROADCAST() && macAddr != LAddress::L2NULL());
+        myMacAddr = macAddr;
+    }
+
 protected:
     /**
      * @brief Registers this bridge's NIC with INET's InterfaceTable.

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -584,10 +584,20 @@ void Mac1609_4::handleLowerMsg(cMessage* msg)
                 wsm->setControlInfo(new PhyToMacControlInfo(res));
                 handleUnicast(macPkt->getSrcAddr(), std::move(wsm));
             }
+            else {
+                delete res;
+                EV_TRACE << "Artificially dropping frame";
+            }
         }
     }
     else if (dest == LAddress::L2BROADCAST()) {
-        if (frameReceived) handleBroadcast(macPkt, res);
+        if (frameReceived) {
+            handleBroadcast(macPkt, res);
+        }
+        else {
+            delete res;
+            EV_TRACE << "Artificially dropping frame";
+        }
     }
     else {
         EV_TRACE << "Packet not for me" << std::endl;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.cc
@@ -570,7 +570,8 @@ void Mac1609_4::handleLowerMsg(cMessage* msg)
     if (dest == myMacAddr) {
         if (auto* ack = dynamic_cast<Mac80211Ack*>(macPkt)) {
             ASSERT(useAcks);
-            handleAck(ack);
+            if (dblrand() >= ackErrorRate) handleAck(ack);
+            else EV_TRACE << "Artificially dropping ACK";
             delete res;
         }
         else {

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.h
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.h
@@ -296,6 +296,7 @@ protected:
     std::string myId;
 
     bool useAcks;
+    double frameErrorRate;
     double ackErrorRate;
     int dot11RTSThreshold;
     int dot11ShortRetryLimit;

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
@@ -66,7 +66,7 @@ simple Mac1609_4 extends BaseMacLayer
         int dot11LongRetryLimit = default(4);
         int ackLength @unit(bit) = default(112bit);
         bool useAcks = default(false);
-        double ackErrorRate = default(0.20);
+        double ackErrorRate = default(0);
 
         // signal informing interested application about channel busy state
         @signal[org_car2x_veins_modules_mac_sigChannelBusy](type=bool);

--- a/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
+++ b/src/veins/modules/mac/ieee80211p/Mac1609_4.ned
@@ -66,6 +66,8 @@ simple Mac1609_4 extends BaseMacLayer
         int dot11LongRetryLimit = default(4);
         int ackLength @unit(bit) = default(112bit);
         bool useAcks = default(false);
+        // artificial drop rates for data frames and acknowledgements for testing purposes
+        double frameErrorRate = default(0);
         double ackErrorRate = default(0);
 
         // signal informing interested application about channel busy state


### PR DESCRIPTION
While using the newly implemented unicast mechanism of `Mac1609_4`, I've noticed that there was an `ackErrorRate` parameter, but the dropping mechanism was not implemented. I believe having artificial packet losses is a great feature when testing the behavior of communication protocols that require reliable delivery, so I implemented the mechanism. In addition, I modified the default drop rate value from `0.20` to `0`, as I believe this must be enabled only on purpose.
In addition to the ACK drop mechanism, I implemented the data frame dropping mechanism, enabled by the `frameErrorRate` parameter (default `0`).
Finally, I've added a method to the `BaseMacLayer` class to enable setting the MAC address.