### PR TITLE
Add acceleration to mobility + traci interface to veins_inet3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ doc/neddoc
 
 /out
 
+/.settings
+/.csettings
+
 examples/**/results
 examples/**/.tkenvrc
 examples/**/.qtenvrc
@@ -20,6 +23,8 @@ examples/**/valgrind.out
 
 subprojects/veins_catch/out
 subprojects/veins_catch/run
+subprojects/veins_catch/.settings
+subprojects/veins_catch/.csettings
 subprojects/veins_catch/src/*.dll
 subprojects/veins_catch/src/*.dylib
 subprojects/veins_catch/src/*.so
@@ -35,6 +40,8 @@ subprojects/veins_inet3/src/**/*_m.h
 subprojects/veins_inet3/src/**/*_m.cc
 subprojects/veins_inet3/out
 subprojects/veins_inet3/run
+subprojects/veins_inet3/.settings
+subprojects/veins_inet3/.csettings
 subprojects/veins_inet3/examples/**/results
 subprojects/veins_inet3/examples/**/.tkenvrc
 subprojects/veins_inet3/examples/**/.qtenvrc
@@ -49,6 +56,8 @@ subprojects/veins_inet/src/**/*_m.h
 subprojects/veins_inet/src/**/*_m.cc
 subprojects/veins_inet/out
 subprojects/veins_inet/run
+subprojects/veins_inet/.settings
+subprojects/veins_inet/.csettings
 subprojects/veins_inet/examples/**/results
 subprojects/veins_inet/examples/**/.tkenvrc
 subprojects/veins_inet/examples/**/.qtenvrc
@@ -63,6 +72,8 @@ subprojects/veins_testsims/src/**/*_m.h
 subprojects/veins_testsims/src/**/*_m.cc
 subprojects/veins_testsims/out
 subprojects/veins_testsims/run
+subprojects/veins_testsims/.settings
+subprojects/veins_testsims/.csettings
 subprojects/veins_testsims/sim/**/results
 subprojects/veins_testsims/sim/**/veins-runall-output
 subprojects/veins_testsims/sim/**/.tkenvrc

--- a/examples/veins/omnetpp.ini
+++ b/examples/veins/omnetpp.ini
@@ -104,6 +104,7 @@ sim-time-limit = 200s
 *.node[*].veinsmobility.y = 0
 *.node[*].veinsmobility.z = 0
 *.node[*].veinsmobility.setHostSpeed = false
+*.node[*].veinsmobility.setHostAcceleration = false
 *.node[*0].veinsmobility.accidentCount = 1
 *.node[*0].veinsmobility.accidentStart = 73s
 *.node[*0].veinsmobility.accidentDuration = 50s

--- a/src/veins/base/modules/BaseMobility.h
+++ b/src/veins/base/modules/BaseMobility.h
@@ -185,6 +185,12 @@ public:
         return move.getDirection() * move.getSpeed();
     }
 
+    /** @brief Returns the current acceleration at the current simulation time. */
+    virtual Coord getCurrentAcceleration() const
+    {
+        return move.getDirection() * move.getAcceleration();
+    }
+
     virtual Coord getCurrentDirection() const
     {
         return move.getDirection();

--- a/src/veins/base/utils/Move.h
+++ b/src/veins/base/utils/Move.h
@@ -55,6 +55,8 @@ protected:
     Coord direction;
     /** @brief speed of the host in meters per second **/
     double speed;
+    /** @brief accel of the host in meters per second per second **/
+    double acceleration;
 
 public:
     Move()
@@ -64,6 +66,7 @@ public:
         , orientation()
         , direction()
         , speed(0.0)
+        , acceleration(0.0)
     {
     }
     Move(const Move& mSrc)
@@ -73,7 +76,24 @@ public:
         , orientation(mSrc.orientation)
         , direction(mSrc.direction)
         , speed(mSrc.speed)
+        , acceleration(mSrc.acceleration)
     {
+    }
+
+    /**
+     * @brief Returns the current accel.
+     */
+    double getAcceleration() const
+    {
+        return acceleration;
+    }
+
+    /**
+     * @brief Sets the current acceleration in meters per second per second.
+     */
+    void setAcceleration(double acceleration)
+    {
+        this->acceleration = acceleration;
     }
 
     /**

--- a/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
+++ b/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
@@ -159,6 +159,8 @@ void DemoBaseApplLayer::populateWSM(BaseFrame1609_4* wsm, LAddress::L2Type rcvId
     if (DemoSafetyMessage* bsm = dynamic_cast<DemoSafetyMessage*>(wsm)) {
         bsm->setSenderPos(curPosition);
         bsm->setSenderSpeed(curSpeed);
+        bsm->setSenderAcceleration(curAcceleration);
+        bsm->setSenderHeading(curHeading);
         bsm->setPsid(-1);
         bsm->setChannelNumber(static_cast<int>(Channel::cch));
         bsm->addBitLength(beaconLengthBits);
@@ -196,6 +198,9 @@ void DemoBaseApplLayer::handlePositionUpdate(cObject* obj)
     ChannelMobilityPtrType const mobility = check_and_cast<ChannelMobilityPtrType>(obj);
     curPosition = mobility->getPositionAt(simTime());
     curSpeed = mobility->getCurrentSpeed();
+    curAcceleration = mobility->getCurrentAcceleration();
+    curHeading = mobility->getCurrentDirection();
+
 }
 
 void DemoBaseApplLayer::handleParkingUpdate(cObject* obj)

--- a/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.h
+++ b/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.h
@@ -166,6 +166,8 @@ protected:
     /* state of the vehicle */
     Coord curPosition;
     Coord curSpeed;
+    Coord curAcceleration;
+    Coord curHeading;
     LAddress::L2Type myId = 0;
     int mySCH;
 

--- a/src/veins/modules/messages/DemoSafetyMessage.msg
+++ b/src/veins/modules/messages/DemoSafetyMessage.msg
@@ -35,4 +35,6 @@ class LAddress::L2Type extends void;
 packet DemoSafetyMessage extends BaseFrame1609_4 {
     Coord senderPos;
     Coord senderSpeed;
+    Coord senderAcceleration;
+    Coord senderHeading;
 }

--- a/src/veins/modules/mobility/traci/TraCIMobility.cc
+++ b/src/veins/modules/mobility/traci/TraCIMobility.cc
@@ -73,6 +73,7 @@ void TraCIMobility::initialize(int stage)
 
         hostPositionOffset = par("hostPositionOffset");
         setHostSpeed = par("setHostSpeed");
+        setHostAcceleration = par("setHostAcceleration");
         accidentCount = par("accidentCount");
 
         currentPosXVec.setName("posx");
@@ -148,7 +149,7 @@ void TraCIMobility::handleSelfMsg(cMessage* msg)
     }
 }
 
-void TraCIMobility::preInitialize(std::string external_id, const Coord& position, std::string road_id, double speed, Heading heading)
+void TraCIMobility::preInitialize(std::string external_id, const Coord& position, std::string road_id, double speed, double acceleration, Heading heading)
 {
     this->external_id = external_id;
     this->lastUpdate = 0;
@@ -156,8 +157,10 @@ void TraCIMobility::preInitialize(std::string external_id, const Coord& position
     this->road_id = road_id;
     this->speed = speed;
     this->heading = heading;
+    this->acceleration = acceleration;
     this->hostPositionOffset = par("hostPositionOffset");
     this->setHostSpeed = par("setHostSpeed");
+    this->setHostAcceleration = par("setHostAcceleration");
 
     Coord nextPos = calculateHostPosition(roadPosition);
     nextPos.z = move.getStartPosition().z;
@@ -168,17 +171,21 @@ void TraCIMobility::preInitialize(std::string external_id, const Coord& position
     if (this->setHostSpeed) {
         move.setSpeed(speed);
     }
+    if (this->setHostAcceleration) {
+        move.setAcceleration(acceleration);
+    }
 
     isPreInitialized = true;
 }
 
-void TraCIMobility::nextPosition(const Coord& position, std::string road_id, double speed, Heading heading, VehicleSignalSet signals)
+void TraCIMobility::nextPosition(const Coord& position, std::string road_id, double speed, double acceleration, Heading heading, VehicleSignalSet signals)
 {
     EV_DEBUG << "nextPosition " << position.x << " " << position.y << " " << road_id << " " << speed << " " << heading << std::endl;
     isPreInitialized = false;
     this->roadPosition = position;
     this->road_id = road_id;
     this->speed = speed;
+    this->acceleration = acceleration;
     this->heading = heading;
     this->signals = signals;
 
@@ -239,6 +246,9 @@ void TraCIMobility::changePosition()
     move.setOrientationByVector(heading.toCoord());
     if (this->setHostSpeed) {
         move.setSpeed(speed);
+    }
+    if (this->setHostAcceleration) {
+        move.setAcceleration(acceleration);
     }
     fixIfHostGetsOutside();
     updatePosition();

--- a/src/veins/modules/mobility/traci/TraCIMobility.h
+++ b/src/veins/modules/mobility/traci/TraCIMobility.h
@@ -92,8 +92,8 @@ public:
     void finish() override;
 
     void handleSelfMsg(cMessage* msg) override;
-    virtual void preInitialize(std::string external_id, const Coord& position, std::string road_id = "", double speed = -1, Heading heading = Heading::nan);
-    virtual void nextPosition(const Coord& position, std::string road_id = "", double speed = -1, Heading heading = Heading::nan, VehicleSignalSet signals = {VehicleSignal::undefined});
+    virtual void preInitialize(std::string external_id, const Coord& position, std::string road_id = "", double speed = -1,  double acceleration = -1, Heading heading = Heading::nan);
+    virtual void nextPosition(const Coord& position, std::string road_id = "", double speed = -1, double acceleration = -1, Heading heading = Heading::nan, VehicleSignalSet signals = {VehicleSignal::undefined});
     virtual void changePosition();
     virtual void changeParkingState(bool);
     virtual void setExternalId(std::string external_id)
@@ -160,6 +160,16 @@ public:
         return BaseMobility::getCurrentSpeed();
     }
 
+    double getplaygroundSizeX() const
+    {
+        return BaseMobility::playgroundSizeX();
+    }
+
+    double getplaygroundSizeY() const
+    {
+        return BaseMobility::playgroundSizeY();
+    }
+
 protected:
     int accidentCount; /**< number of accidents */
 
@@ -176,12 +186,14 @@ protected:
     std::string external_id; /**< updated by setExternalId() */
     double hostPositionOffset; /**< front offset for the antenna on this car */
     bool setHostSpeed; /**< whether to update the speed of the host (along with its position)  */
+    bool setHostAcceleration; /**< whether to update the accel of the host (along with its position)  */
 
     simtime_t lastUpdate; /**< updated by nextPosition() */
     Coord roadPosition; /**< position of front bumper, updated by nextPosition() */
     std::string road_id; /**< updated by nextPosition() */
     double speed; /**< updated by nextPosition() */
     Heading heading; /**< updated by nextPosition() */
+    double acceleration; /**< updated by nextPosition() */
     VehicleSignalSet signals; /**<updated by nextPosition() */
 
     cMessage* startAccidentMsg;

--- a/src/veins/modules/mobility/traci/TraCIMobility.ned
+++ b/src/veins/modules/mobility/traci/TraCIMobility.ned
@@ -45,6 +45,8 @@ simple TraCIMobility extends BaseMobility
         @display("i=block/cogwheel");
         double hostPositionOffset @unit("m") = default(0.0m);  // shift OMNeT++ module this far from front of the car
         bool setHostSpeed = default(false);  // whether to update the speed of the host (along with its position)
+        bool setHostAcceleration = default(false);  // whether to update the acceleration of the host (along with its position)
+        
         int accidentCount = default(0);  // number of accidents
         double accidentStart @unit("s") = default(uniform(30s,60s));  // time until first accident, relative to departure time
         volatile double accidentDuration @unit("s") = default(uniform(30s,60s));  // duration of accident

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -167,9 +167,9 @@ protected:
 
     virtual void init_traci();
 
-    virtual void preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, Heading heading, VehicleSignalSet signals);
-    virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, Heading heading, VehicleSignalSet signals);
-    void addModule(std::string nodeId, std::string type, std::string name, std::string displayString, const Coord& position, std::string road_id = "", double speed = -1, Heading heading = Heading::nan, VehicleSignalSet signals = {VehicleSignal::undefined}, double length = 0, double height = 0, double width = 0);
+    virtual void preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, double acceleration, Heading heading, VehicleSignalSet signals);
+    virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, double acceleration, Heading heading, VehicleSignalSet signals);
+    void addModule(std::string nodeId, std::string type, std::string name, std::string displayString, const Coord& position, std::string road_id = "", double speed = -1, double acceleration = -1, Heading heading = Heading::nan, VehicleSignalSet signals = {VehicleSignal::undefined}, double length = 0, double height = 0, double width = 0);
     cModule* getManagedModule(std::string nodeId); /**< returns a pointer to the managed module named moduleName, or 0 if no module can be found */
     void deleteManagedModule(std::string nodeId);
 

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.cc
@@ -58,20 +58,20 @@ void VeinsInetManager::initialize(int stage)
 #endif
 }
 
-void VeinsInetManager::preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, Heading heading, VehicleSignalSet signals)
+void VeinsInetManager::preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, double acceleration, Heading heading, VehicleSignalSet signals)
 {
     // pre-initialize VeinsInetMobility
     auto mobilityModules = getSubmodulesOfType<VeinsInetMobility>(mod);
     for (auto inetmm : mobilityModules) {
-        inetmm->preInitialize(nodeId, inet::Coord(position.x, position.y), road_id, speed, heading.getRad());
+        inetmm->preInitialize(nodeId, inet::Coord(position.x, position.y), road_id, speed, acceleration, heading.getRad());
     }
 }
 
-void VeinsInetManager::updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, Heading heading, VehicleSignalSet signals)
+void VeinsInetManager::updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, double acceleration, Heading heading, VehicleSignalSet signals)
 {
     // update position in VeinsInetMobility
     auto mobilityModules = getSubmodulesOfType<VeinsInetMobility>(mod);
     for (auto inetmm : mobilityModules) {
-        inetmm->nextPosition(inet::Coord(p.x, p.y), edge, speed, heading.getRad());
+        inetmm->nextPosition(inet::Coord(p.x, p.y), edge, speed, acceleration, heading.getRad());
     }
 }

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetManager.h
@@ -44,8 +44,8 @@ public:
 
     void initialize(int stage) override;
 
-    virtual void preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, Heading heading, VehicleSignalSet signals) override;
-    virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, Heading heading, VehicleSignalSet signals) override;
+    virtual void preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, double acceleration, Heading heading, VehicleSignalSet signals) override;
+    virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, double acceleration, Heading heading, VehicleSignalSet signals) override;
 
 protected:
     SignalManager signalManager;

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
@@ -97,7 +97,7 @@ inet::Coord VeinsInetMobility::getCurrentVelocity()
 
 inet::Coord VeinsInetMobility::getCurrentAcceleration()
 {
-    throw lastAcceleration;
+    return lastAcceleration;
 }
 
 inet::Quaternion VeinsInetMobility::getCurrentAngularPosition()

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
@@ -46,12 +46,13 @@ VeinsInetMobility::~VeinsInetMobility()
     delete vehicleCommandInterface;
 }
 
-void VeinsInetMobility::preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double angle)
+void VeinsInetMobility::preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle)
 {
     Enter_Method_Silent();
     this->external_id = external_id;
     lastPosition = position;
     lastVelocity = inet::Coord(cos(angle), -sin(angle)) * speed;
+    lastAcceleration = inet::Coord(cos(angle), -sin(angle)) * acceleration;
     lastOrientation = inet::Quaternion(inet::EulerAngles(rad(-angle), rad(0.0), rad(0.0)));
 }
 
@@ -63,12 +64,13 @@ void VeinsInetMobility::initialize(int stage)
     ASSERT(hasPar("initFromDisplayString") && par("initFromDisplayString"));
 }
 
-void VeinsInetMobility::nextPosition(const inet::Coord& position, std::string road_id, double speed, double angle)
+void VeinsInetMobility::nextPosition(const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle)
 {
     Enter_Method_Silent();
 
     lastPosition = position;
     lastVelocity = inet::Coord(cos(angle), -sin(angle)) * speed;
+    lastAcceleration = inet::Coord(cos(angle), -sin(angle)) * acceleration;
     lastOrientation = inet::Quaternion(inet::EulerAngles(rad(-angle), rad(0.0), rad(0.0)));
 
     // Update display string to show node is getting updates
@@ -95,7 +97,7 @@ inet::Coord VeinsInetMobility::getCurrentVelocity()
 
 inet::Coord VeinsInetMobility::getCurrentAcceleration()
 {
-    throw cRuntimeError("Invalid operation");
+    throw lastAcceleration;
 }
 
 inet::Quaternion VeinsInetMobility::getCurrentAngularPosition()

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.h
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.h
@@ -47,12 +47,12 @@ public:
     virtual ~VeinsInetMobility();
 
     /** @brief called by class VeinsInetManager */
-    virtual void preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double angle);
+    virtual void preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle);
 
     virtual void initialize(int stage) override;
 
     /** @brief called by class VeinsInetManager */
-    virtual void nextPosition(const inet::Coord& position, std::string road_id, double speed, double angle);
+    virtual void nextPosition(const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle);
 
     virtual inet::Coord getCurrentPosition() override;
     virtual inet::Coord getCurrentVelocity() override;
@@ -70,6 +70,9 @@ public:
 protected:
     /** @brief The last velocity that was set by nextPosition(). */
     inet::Coord lastVelocity;
+
+    /** @brief The last acceleration that was set by nextPosition(). */
+    inet::Coord lastAcceleration;
 
     /** @brief The last angular velocity that was set by nextPosition(). */
     inet::Quaternion lastAngularVelocity;

--- a/subprojects/veins_inet3/src/veins_inet/VeinsInetManagerBase.cc
+++ b/subprojects/veins_inet3/src/veins_inet/VeinsInetManagerBase.cc
@@ -29,26 +29,26 @@ using veins::VeinsInetManagerBase;
 
 Define_Module(veins::VeinsInetManagerBase);
 
-void VeinsInetManagerBase::preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, Heading heading, VehicleSignalSet signals)
+void VeinsInetManagerBase::preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, double acceleration, Heading heading, VehicleSignalSet signals)
 {
-    TraCIScenarioManager::preInitializeModule(mod, nodeId, position, road_id, speed, heading, signals);
+    TraCIScenarioManager::preInitializeModule(mod, nodeId, position, road_id, speed, acceleration, heading, signals);
     // pre-initialize VeinsInetMobility
     for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
         cModule* submod = *iter;
         VeinsInetMobility* inetmm = dynamic_cast<VeinsInetMobility*>(submod);
         if (!inetmm) return;
-        inetmm->preInitialize(nodeId, inet::Coord(position.x, position.y), road_id, speed, heading.getRad());
+        inetmm->preInitialize(nodeId, inet::Coord(position.x, position.y), road_id, speed, acceleration, heading.getRad());
     }
 }
 
-void VeinsInetManagerBase::updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, Heading heading, VehicleSignalSet signals)
+void VeinsInetManagerBase::updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, double acceleration, Heading heading, VehicleSignalSet signals)
 {
-    TraCIScenarioManager::updateModulePosition(mod, p, edge, speed, heading, signals);
+    TraCIScenarioManager::updateModulePosition(mod, p, edge, speed, acceleration, heading, signals);
     // update position in VeinsInetMobility
     for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
         cModule* submod = *iter;
         VeinsInetMobility* inetmm = dynamic_cast<VeinsInetMobility*>(submod);
         if (!inetmm) return;
-        inetmm->nextPosition(inet::Coord(p.x, p.y), edge, speed, heading.getRad());
+        inetmm->nextPosition(inet::Coord(p.x, p.y), edge, speed, acceleration, heading.getRad());
     }
 }

--- a/subprojects/veins_inet3/src/veins_inet/VeinsInetManagerBase.h
+++ b/subprojects/veins_inet3/src/veins_inet/VeinsInetManagerBase.h
@@ -39,8 +39,8 @@ namespace veins {
  */
 class VEINS_INET_API VeinsInetManagerBase : virtual public TraCIScenarioManager {
 public:
-    virtual void preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, Heading heading, VehicleSignalSet signals) override;
-    virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, Heading heading, VehicleSignalSet signals) override;
+    virtual void preInitializeModule(cModule* mod, const std::string& nodeId, const Coord& position, const std::string& road_id, double speed, double acceleration, Heading heading, VehicleSignalSet signals) override;
+    virtual void updateModulePosition(cModule* mod, const Coord& p, const std::string& edge, double speed, double acceleration, Heading heading, VehicleSignalSet signals) override;
 };
 
 class VEINS_INET_API VeinsInetManagerBaseAccess {

--- a/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.cc
+++ b/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.cc
@@ -48,25 +48,28 @@ VeinsInetMobility::VeinsInetMobility()
     , lastSpeed(Coord::ZERO)
     , lastOrientation(inet::EulerAngles::ZERO)
 {
+    lastAcceleration = Coord::ZERO;
 }
 
 //
 // Public, called from manager
 //
 
-void VeinsInetMobility::preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double angle)
+void VeinsInetMobility::preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle)
 {
     Enter_Method_Silent();
     lastPosition = position;
     lastSpeed = Coord(cos(angle), -sin(angle)) * speed;
+    lastAcceleration = Coord(cos(angle), -sin(angle)) * acceleration;
     lastOrientation.alpha = -angle;
 }
 
-void VeinsInetMobility::nextPosition(const inet::Coord& position, std::string road_id, double speed, double angle)
+void VeinsInetMobility::nextPosition(const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle)
 {
     Enter_Method_Silent();
     lastPosition = position;
     lastSpeed = Coord(cos(angle), -sin(angle)) * speed;
+    lastAcceleration = Coord(cos(angle), -sin(angle)) * acceleration;
     lastOrientation.alpha = -angle;
 
     // Update display string to show node is getting updates
@@ -101,10 +104,16 @@ Coord VeinsInetMobility::getCurrentSpeed()
     return lastSpeed;
 }
 
+Coord VeinsInetMobility::getCurrentAcceleration()
+{
+    return lastAcceleration;
+}
+
 inet::EulerAngles VeinsInetMobility::getCurrentAngularPosition()
 {
     return lastOrientation;
 }
+
 
 //
 // Protected

--- a/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.cc
+++ b/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.cc
@@ -32,8 +32,6 @@
 
 namespace veins {
 
-using inet::Coord;
-
 Register_Class(VeinsInetMobility);
 
 //
@@ -42,13 +40,13 @@ Register_Class(VeinsInetMobility);
 
 VeinsInetMobility::VeinsInetMobility()
     : visualRepresentation(nullptr)
-    , constraintAreaMin(Coord::ZERO)
-    , constraintAreaMax(Coord::ZERO)
-    , lastPosition(Coord::ZERO)
-    , lastSpeed(Coord::ZERO)
+    , constraintAreaMin(inet::Coord::ZERO)
+    , constraintAreaMax(inet::Coord::ZERO)
+    , lastPosition(inet::Coord::ZERO)
+    , lastSpeed(inet::Coord::ZERO)
     , lastOrientation(inet::EulerAngles::ZERO)
 {
-    lastAcceleration = Coord::ZERO;
+    lastAcceleration = inet::Coord::ZERO;
 }
 
 //
@@ -59,8 +57,8 @@ void VeinsInetMobility::preInitialize(std::string external_id, const inet::Coord
 {
     Enter_Method_Silent();
     lastPosition = position;
-    lastSpeed = Coord(cos(angle), -sin(angle)) * speed;
-    lastAcceleration = Coord(cos(angle), -sin(angle)) * acceleration;
+    lastSpeed = inet::Coord(cos(angle), -sin(angle)) * speed;
+    lastAcceleration = inet::Coord(cos(angle), -sin(angle)) * acceleration;
     lastOrientation.alpha = -angle;
 }
 
@@ -68,8 +66,8 @@ void VeinsInetMobility::nextPosition(const inet::Coord& position, std::string ro
 {
     Enter_Method_Silent();
     lastPosition = position;
-    lastSpeed = Coord(cos(angle), -sin(angle)) * speed;
-    lastAcceleration = Coord(cos(angle), -sin(angle)) * acceleration;
+    lastSpeed = inet::Coord(cos(angle), -sin(angle)) * speed;
+    lastAcceleration = inet::Coord(cos(angle), -sin(angle)) * acceleration;
     lastOrientation.alpha = -angle;
 
     // Update display string to show node is getting updates
@@ -94,17 +92,17 @@ double VeinsInetMobility::getMaxSpeed() const
     return NaN;
 }
 
-Coord VeinsInetMobility::getCurrentPosition()
+inet::Coord VeinsInetMobility::getCurrentPosition()
 {
     return lastPosition;
 }
 
-Coord VeinsInetMobility::getCurrentSpeed()
+inet::Coord VeinsInetMobility::getCurrentSpeed()
 {
     return lastSpeed;
 }
 
-Coord VeinsInetMobility::getCurrentAcceleration()
+inet::Coord VeinsInetMobility::getCurrentAcceleration()
 {
     return lastAcceleration;
 }
@@ -161,6 +159,30 @@ void VeinsInetMobility::updateVisualRepresentation()
 void VeinsInetMobility::emitMobilityStateChangedSignal()
 {
     emit(mobilityStateChangedSignal, this);
+}
+
+std::string VeinsInetMobility::getExternalId() const
+{
+    if (external_id == "") throw cRuntimeError("VeinsInetMobility::getExternalId called with no external_id set yet");
+    return external_id;
+}
+
+TraCIScenarioManager* VeinsInetMobility::getManager() const
+{
+    if (!manager) manager = TraCIScenarioManagerAccess().get();
+    return manager;
+}
+
+TraCICommandInterface* VeinsInetMobility::getCommandInterface() const
+{
+    if (!commandInterface) commandInterface = getManager()->getCommandInterface();
+    return commandInterface;
+}
+
+TraCICommandInterface::Vehicle* VeinsInetMobility::getVehicleCommandInterface() const
+{
+    if (!vehicleCommandInterface) vehicleCommandInterface = new TraCICommandInterface::Vehicle(getCommandInterface()->vehicle(getExternalId()));
+    return vehicleCommandInterface;
 }
 
 } // namespace veins

--- a/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.h
+++ b/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.h
@@ -36,6 +36,9 @@
 
 #include "veins_inet/veins_inet.h"
 
+#include "veins/modules/mobility/traci/TraCIScenarioManager.h"
+#include "veins/modules/mobility/traci/TraCICommandInterface.h"
+
 namespace veins {
 
 class VEINS_INET_API VeinsInetMobility : public cSimpleModule, public inet::IMobility {
@@ -66,6 +69,18 @@ public:
     {
         return constraintAreaMin;
     }
+
+public:
+    virtual std::string getExternalId() const;
+    virtual TraCIScenarioManager* getManager() const;
+    virtual TraCICommandInterface* getCommandInterface() const;
+    virtual TraCICommandInterface::Vehicle* getVehicleCommandInterface() const;
+
+protected:
+    std::string external_id; /**< identifier used by TraCI server to refer to this node */
+    mutable TraCIScenarioManager* manager = nullptr; /**< cached value */
+    mutable TraCICommandInterface* commandInterface = nullptr; /**< cached value */
+    mutable TraCICommandInterface::Vehicle* vehicleCommandInterface = nullptr; /**< cached value */
 
 protected:
     cModule* visualRepresentation;

--- a/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.h
+++ b/subprojects/veins_inet3/src/veins_inet/VeinsInetMobility.h
@@ -43,14 +43,15 @@ public:
     VeinsInetMobility();
 
 public:
-    virtual void preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double angle);
-    virtual void nextPosition(const inet::Coord& position, std::string road_id, double speed, double angle);
+    virtual void preInitialize(std::string external_id, const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle);
+    virtual void nextPosition(const inet::Coord& position, std::string road_id, double speed, double acceleration, double angle);
 
 public:
     virtual double getMaxSpeed() const override;
 
     virtual inet::Coord getCurrentPosition() override;
     virtual inet::Coord getCurrentSpeed() override;
+    inet::Coord getCurrentAcceleration();
     virtual inet::EulerAngles getCurrentAngularPosition() override;
     virtual inet::EulerAngles getCurrentAngularSpeed() override
     {
@@ -74,6 +75,7 @@ protected:
 
     inet::Coord lastPosition;
     inet::Coord lastSpeed;
+    inet::Coord lastAcceleration;
     inet::EulerAngles lastOrientation;
 
 protected:


### PR DESCRIPTION
## Description

- add traciCommandInterface and traciScenarioManager access to veins_inet3
- add the instant acceleration value from sumo to the veins mobility modules

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [X] Test the veins example
- [X] Test the f2md example
- [X] Test compatibility with simulte (OpenCV2X version)

**Test Configuration**:
* OMNeT++ v5.6.1
* SUMO v1.5.0
* Inet v3.3.6 (for veins_inet3)
* Inet v4.2.0 (for veins_inet)

# Checklist:

- [X] Code can be automatically merged