### PR TITLE
Pulls/traci playground

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -397,6 +397,11 @@ void TraCIScenarioManager::init_traci()
                 std::list<Coord> coords = commandInterface->polygon(id).getShape();
                 std::vector<Coord> shape;
                 std::copy(coords.begin(), coords.end(), std::back_inserter(shape));
+                for (auto p : shape) {
+                    if ((p.x < 0) || (p.y < 0) || (p.x > world->getPgs()->x) || (p.y > world->getPgs()->y)) {
+                        EV_WARN << "WARNING: Playground (" << world->getPgs()->x << ", " << world->getPgs()->y << ") will not fit radio obstacle at (" << p.x << ", " << p.y << ")" << endl;
+                    }
+                }
                 obstacles->addFromTypeAndShape(id, typeId, shape);
             }
         }

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -306,7 +306,7 @@ void TraCIScenarioManager::init_traci()
         // query and set road network boundaries
         auto networkBoundaries = commandInterface->initNetworkBoundaries(par("margin"));
         if (world != nullptr && ((connection->traci2omnet(networkBoundaries.second).x > world->getPgs()->x) || (connection->traci2omnet(networkBoundaries.first).y > world->getPgs()->y))) {
-            EV_DEBUG << "WARNING: Playground size (" << world->getPgs()->x << ", " << world->getPgs()->y << ") might be too small for vehicle at network bounds (" << connection->traci2omnet(networkBoundaries.second).x << ", " << connection->traci2omnet(networkBoundaries.first).y << ")" << endl;
+            EV_WARN << "WARNING: Playground size (" << world->getPgs()->x << ", " << world->getPgs()->y << ") might be too small for vehicle at network bounds (" << connection->traci2omnet(networkBoundaries.second).x << ", " << connection->traci2omnet(networkBoundaries.first).y << ")" << endl;
         }
     }
 

--- a/src/veins/modules/utility/BBoxLookup.cc
+++ b/src/veins/modules/utility/BBoxLookup.cc
@@ -111,12 +111,16 @@ BBoxLookup::BBoxLookup(const std::vector<Obstacle*>& obstacles, std::function<BB
     size_t numEntries = 0;
     for (const auto obstaclePtr : obstacles) {
         auto bbox = makeBBox(obstaclePtr);
-        const size_t fromCol = std::max(0, int(bbox.p1.x / cellSize));
-        const size_t toCol = std::max(0, int(bbox.p2.x / cellSize));
-        const size_t fromRow = std::max(0, int(bbox.p1.y / cellSize));
-        const size_t toRow = std::max(0, int(bbox.p2.y / cellSize));
+        const size_t fromCol = std::min(size_t(std::max(0, int(bbox.p1.x / cellSize))), numCols - 1);
+        const size_t toCol = std::min(size_t(std::max(0, int(bbox.p2.x / cellSize))), numCols - 1);
+        const size_t fromRow = std::min(size_t(std::max(0, int(bbox.p1.y / cellSize))), numRows - 1);
+        const size_t toRow = std::min(size_t(std::max(0, int(bbox.p2.y / cellSize))), numRows - 1);
         for (size_t row = fromRow; row <= toRow; ++row) {
             for (size_t col = fromCol; col <= toCol; ++col) {
+                ASSERT(row >= 0);
+                ASSERT(col >= 0);
+                ASSERT(row < numRows);
+                ASSERT(col < numCols);
                 const size_t cellIndex = col + row * numCols;
                 protoCells[cellIndex].push_back(bbox);
                 protoLookup[cellIndex].push_back(obstaclePtr);
@@ -163,10 +167,10 @@ std::vector<Obstacle*> BBoxLookup::findOverlapping(Point sender, Point receiver)
     };
 
     // determine coordinates for all cells touched by bbox
-    const size_t firstCol = std::max(0, int(bbox.p1.x / cellSize));
-    const size_t lastCol = std::max(0, int(bbox.p2.x / cellSize));
-    const size_t firstRow = std::max(0, int(bbox.p1.y / cellSize));
-    const size_t lastRow = std::max(0, int(bbox.p2.y / cellSize));
+    const size_t firstCol = std::min(size_t(std::max(0, int(bbox.p1.x / cellSize))), numCols - 1);
+    const size_t lastCol = std::min(size_t(std::max(0, int(bbox.p2.x / cellSize))), numCols - 1);
+    const size_t firstRow = std::min(size_t(std::max(0, int(bbox.p1.y / cellSize))), numRows - 1);
+    const size_t lastRow = std::min(size_t(std::max(0, int(bbox.p2.y / cellSize))), numRows - 1);
     ASSERT(lastCol < numCols && lastRow < numRows);
     // precompute transmission ray properties
     const Ray ray = makeRay(sender, receiver);


### PR DESCRIPTION
@dbuse, `BBoxLookup` was written by you, so this probably needs a review from you.

Some background: it's possible to load a `.net.xml` file and a `.poly.xml` file which use different bounding boxes. As only the _network_ bounding box is accessible via TraCI it's hard to come up with a clever conversion for coordinates beyond "clipping at the network boundary", which this commit tries to introduce.
