### PR TITLE
Finding multiple submodules and renaming directIn gate

### DIFF
--- a/src/veins/base/utils/FindModule.h
+++ b/src/veins/base/utils/FindModule.h
@@ -56,6 +56,26 @@ public:
         }
         return NULL;
     }
+    /**
+     * @brief Returns a list of pointers to sub modules of the passed module with
+     * the type of this template.
+     *
+     * Returns an empty list if no matching submodule could be found.
+     */
+    static std::vector<T> findSubModules(const cModule* const top)
+    {
+        std::vector<T> modules;
+        for (cModule::SubmoduleIterator i(top); !i.end(); i++) {
+            cModule* const sub = *i;
+            // this allows also a return type of read only pointer: const cModule *const
+            T dCastRet = dynamic_cast<T>(sub);
+            if (dCastRet != NULL) modules.push_back(dCastRet);
+            // this allows also a return type of read only pointer: const cModule *const
+            std::vector<T> recFnd = findSubModules(sub);
+            if (recFnd.size()) std::copy(recFnd.begin(), recFnd.end(), std::back_inserter(modules));;
+        }
+        return modules;
+    }
 
     /**
      * @brief Returns a pointer to the module with the type of this

--- a/subprojects/veins_inet3/src/veins_inet/VeinsInetManagerBase.cc
+++ b/subprojects/veins_inet3/src/veins_inet/VeinsInetManagerBase.cc
@@ -36,7 +36,7 @@ void VeinsInetManagerBase::preInitializeModule(cModule* mod, const std::string& 
     for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
         cModule* submod = *iter;
         VeinsInetMobility* inetmm = dynamic_cast<VeinsInetMobility*>(submod);
-        if (!inetmm) return;
+        if (!inetmm) continue;
         inetmm->preInitialize(nodeId, inet::Coord(position.x, position.y), road_id, speed, heading.getRad());
     }
 }
@@ -48,7 +48,7 @@ void VeinsInetManagerBase::updateModulePosition(cModule* mod, const Coord& p, co
     for (cModule::SubmoduleIterator iter(mod); !iter.end(); iter++) {
         cModule* submod = *iter;
         VeinsInetMobility* inetmm = dynamic_cast<VeinsInetMobility*>(submod);
-        if (!inetmm) return;
+        if (!inetmm) continue;
         inetmm->nextPosition(inet::Coord(p.x, p.y), edge, speed, heading.getRad());
     }
 }


### PR DESCRIPTION
This PR includes ~~two~~ three commits.

1. 479df54 introduces a `findSubModules` method which, differently from `findSubModule` retrieves all the instances of a submodule for a parent module. This is useful, for example, when a vehicle has multiple NIC interfaces of the same type (e.g., VLC front and back) and both of them needs to be retrieved
2. 40b037d renames the direct in gate for the 802.11p NIC from `radioIn` to `veins11pRadioIn`. The name `radioIn` is (ab)used by multiple frameworks, making it often impossible to have multiple heterogeneous radio interfaces. For example, `radioIn` is used by INET as well. This is a proposal as 1) I don't know whether this might break backward compatibility and 2) whether there is a more elegant way to do it (e.g., setting the name as a parameter of the connection manager which in turn passes it to NicEntryDirect, if a user needs it)
3. b1ae3db fixes what to me seemed like a bug. In the loop, the `return` statement caused the execution to exit the loop, so skipping the update of the position of the mobility module. The question remaining is whether, when we find the mobility module, we want to leave the loop or continue searching for other potential mobility modules of the same type. I see this very unlikely, so that might be optimized with something like
```C++
if (inetmm) {
    inetmm->....
    return;
}
```