### PR TITLE
Update VeinsInetMobility to be compatible with latest INET IMobility

### DIFF
--- a/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
@@ -83,6 +83,7 @@ void VeinsInetMobility::nextPosition(const inet::Coord& position, std::string ro
     emitMobilityStateChangedSignal();
 }
 
+#if INET_VERSION >= 0x0402
 const inet::Coord& VeinsInetMobility::getCurrentPosition()
 {
     return lastPosition;
@@ -112,7 +113,38 @@ const inet::Quaternion& VeinsInetMobility::getCurrentAngularAcceleration()
 {
     throw cRuntimeError("Invalid operation");
 }
+#else
 
+inet::Coord VeinsInetMobility::getCurrentPosition()
+{
+    return lastPosition;
+}
+
+inet::Coord VeinsInetMobility::getCurrentVelocity()
+{
+    return lastVelocity;
+}
+
+inet::Coord VeinsInetMobility::getCurrentAcceleration()
+{
+    throw cRuntimeError("Invalid operation");
+}
+
+inet::Quaternion VeinsInetMobility::getCurrentAngularPosition()
+{
+    return lastOrientation;
+}
+
+inet::Quaternion VeinsInetMobility::getCurrentAngularVelocity()
+{
+    return lastAngularVelocity;
+}
+
+inet::Quaternion VeinsInetMobility::getCurrentAngularAcceleration()
+{
+    throw cRuntimeError("Invalid operation");
+}
+#endif
 void VeinsInetMobility::setInitialPosition()
 {
     subjectModule->getDisplayString().setTagArg("p", 0, lastPosition.x);

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.cc
@@ -83,32 +83,32 @@ void VeinsInetMobility::nextPosition(const inet::Coord& position, std::string ro
     emitMobilityStateChangedSignal();
 }
 
-inet::Coord VeinsInetMobility::getCurrentPosition()
+const inet::Coord& VeinsInetMobility::getCurrentPosition()
 {
     return lastPosition;
 }
 
-inet::Coord VeinsInetMobility::getCurrentVelocity()
+const inet::Coord& VeinsInetMobility::getCurrentVelocity()
 {
     return lastVelocity;
 }
 
-inet::Coord VeinsInetMobility::getCurrentAcceleration()
+const inet::Coord& VeinsInetMobility::getCurrentAcceleration()
 {
     throw cRuntimeError("Invalid operation");
 }
 
-inet::Quaternion VeinsInetMobility::getCurrentAngularPosition()
+const inet::Quaternion& VeinsInetMobility::getCurrentAngularPosition()
 {
     return lastOrientation;
 }
 
-inet::Quaternion VeinsInetMobility::getCurrentAngularVelocity()
+const inet::Quaternion& VeinsInetMobility::getCurrentAngularVelocity()
 {
     return lastAngularVelocity;
 }
 
-inet::Quaternion VeinsInetMobility::getCurrentAngularAcceleration()
+const inet::Quaternion& VeinsInetMobility::getCurrentAngularAcceleration()
 {
     throw cRuntimeError("Invalid operation");
 }

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.h
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.h
@@ -54,13 +54,13 @@ public:
     /** @brief called by class VeinsInetManager */
     virtual void nextPosition(const inet::Coord& position, std::string road_id, double speed, double angle);
 
-    virtual inet::Coord getCurrentPosition() override;
-    virtual inet::Coord getCurrentVelocity() override;
-    virtual inet::Coord getCurrentAcceleration() override;
+    virtual const inet::Coord& getCurrentPosition() override;
+    virtual const inet::Coord& getCurrentVelocity() override;
+    virtual const inet::Coord& getCurrentAcceleration() override;
 
-    virtual inet::Quaternion getCurrentAngularPosition() override;
-    virtual inet::Quaternion getCurrentAngularVelocity() override;
-    virtual inet::Quaternion getCurrentAngularAcceleration() override;
+    virtual const inet::Quaternion& getCurrentAngularPosition() override;
+    virtual const inet::Quaternion& getCurrentAngularVelocity() override;
+    virtual const inet::Quaternion& getCurrentAngularAcceleration() override;
 
     virtual std::string getExternalId() const;
     virtual TraCIScenarioManager* getManager() const;

--- a/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.h
+++ b/subprojects/veins_inet/src/veins_inet/VeinsInetMobility.h
@@ -54,6 +54,7 @@ public:
     /** @brief called by class VeinsInetManager */
     virtual void nextPosition(const inet::Coord& position, std::string road_id, double speed, double angle);
 
+#if INET_VERSION >= 0x0402
     virtual const inet::Coord& getCurrentPosition() override;
     virtual const inet::Coord& getCurrentVelocity() override;
     virtual const inet::Coord& getCurrentAcceleration() override;
@@ -61,6 +62,15 @@ public:
     virtual const inet::Quaternion& getCurrentAngularPosition() override;
     virtual const inet::Quaternion& getCurrentAngularVelocity() override;
     virtual const inet::Quaternion& getCurrentAngularAcceleration() override;
+#else
+    virtual inet::Coord getCurrentPosition() override;
+    virtual inet::Coord getCurrentVelocity() override;
+    virtual inet::Coord getCurrentAcceleration() override;
+
+    virtual inet::Quaternion getCurrentAngularPosition() override;
+    virtual inet::Quaternion getCurrentAngularVelocity() override;
+    virtual inet::Quaternion getCurrentAngularAcceleration() override;
+#endif
 
     virtual std::string getExternalId() const;
     virtual TraCIScenarioManager* getManager() const;


### PR DESCRIPTION
Jun 8th commit for INET made veins_inet to not be compatible with the latest INET IMobility. Commit found here: 
https://github.com/inet-framework/inet/commit/6f75037035effacee211cfbf42e1fb5fdabe340e

This PR updates VeinsInetMobility to match IMobility's contract.