### PR TITLE
Fix SIGSEGV if endSimulation is used

### DIFF
--- a/src/veins/base/phyLayer/BasePhyLayer.cc
+++ b/src/veins/base/phyLayer/BasePhyLayer.cc
@@ -177,7 +177,9 @@ void BasePhyLayer::getParametersFromXML(cXMLElement* xmlData, ParameterMap& outp
 void BasePhyLayer::finish()
 {
     // give decider the chance to do something
-    decider->finish();
+    if (decider != nullptr) {
+        decider->finish();
+    }
 }
 
 // -----Decider initialization----------------------

--- a/src/veins/modules/mobility/traci/TraCIMobility.h
+++ b/src/veins/modules/mobility/traci/TraCIMobility.h
@@ -184,8 +184,8 @@ protected:
     Heading heading; /**< updated by nextPosition() */
     VehicleSignalSet signals; /**<updated by nextPosition() */
 
-    cMessage* startAccidentMsg;
-    cMessage* stopAccidentMsg;
+    cMessage* startAccidentMsg = nullptr;
+    cMessage* stopAccidentMsg = nullptr;
     mutable TraCIScenarioManager* manager;
     mutable TraCICommandInterface* commandInterface;
     mutable TraCICommandInterface::Vehicle* vehicleCommandInterface;


### PR DESCRIPTION
This PR fixes the error described in #194: If `endSimulation()` is called during the initialization of a module, the veins process crashes with a SIGSEGV.

There are two reasons for this:

1. The `decider` field of the `BasePhyLayer` gets accessed in the `finish` method while it is still `nullptr` (presumably because `BasePhyLayer::initialize` has not run yet). This gets fixed in a770af8
2. The `startAccidentMsg` and `stopAccidentMsg` of `TraciMobility` get accessed in the `finish` method while they still contain undefined contents (pointers to a random location in memory). This gets fixed in 7e40643

Together, these two should make it safe to call OMNeT++'s `endSimulation()` function in the init code of a module (at least the application module). Fixes #194 

TODO: remove error-reproduction code/commit before merging. I'm leaving this in here for now to quickly allow reproducing the error.