### PR TITLE
Refactor ChannelAccess::sendToChannel

### DIFF
--- a/src/veins/base/connectionManager/ChannelAccess.cc
+++ b/src/veins/base/connectionManager/ChannelAccess.cc
@@ -91,8 +91,8 @@ void ChannelAccess::sendToChannel(cPacket* msg)
         const auto propagationDelay = calculatePropagationDelay(entry.first);
 
         if (useSendDirect) {
-            for (int i = gate->getBaseId(); i < gate->getBaseId() + gate->size(); i++) {
-                sendDirect(msg->dup(), propagationDelay, msg->getDuration(), gate->getOwnerModule(), i);
+            for (int gateIndex = gate->getBaseId(); gateIndex < gate->getBaseId() + gate->size(); gateIndex++) {
+                sendDirect(msg->dup(), propagationDelay, msg->getDuration(), gate->getOwnerModule(), gateIndex);
             }
         }
         else {

--- a/src/veins/base/connectionManager/ChannelAccess.cc
+++ b/src/veins/base/connectionManager/ChannelAccess.cc
@@ -99,6 +99,7 @@ void ChannelAccess::sendToChannel(cPacket* msg)
             sendDelayed(msg->dup(), propagationDelay, gate);
         }
     }
+    // Original message no longer needed, copies have been sent to all possible receivers.
     delete msg;
 }
 


### PR DESCRIPTION
This PR refactors ChannelAccess::sendToChannel to be more readable with less code duplication.

It also fixes the handling of gate vectors:
- The iteration started at the referenced gate's ID (`radioStart = i->second->getId()`), not at the start of the gate vector. If the referenced `cGate` was not the first gate in the gate vector, the loop would have run past the end of the gate vector.
- In line 105, the loop's end point decreased with each iteration (`g != --radioEnd`).
  - For odd-sized gate vectors (≠1), the would have excluded half of the gates.
  - For even-sized gate vectors, this would have been an infinite loop.

These bugs have been present for at least 14 years, so I doubt anyone has been using gate vectors in this context. I only noticed them because I was refactoring this method in preparation for some unrelated changes.

I have only tested this change with  `useSendDirect = true` and without gate vectors, since I don't have access to any other test cases.