### PR TITLE
Add TraCI methods to TraCICommandInterface

### DIFF
--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -366,6 +366,21 @@ double TraCICommandInterface::Vehicle::getDeccel()
     return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_DECEL, RESPONSE_GET_VEHICLE_VARIABLE);
 }
 
+double TraCICommandInterface::Vehicle::getSpeed()
+{
+    return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_SPEED, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
+double TraCICommandInterface::Vehicle::getAcceleration()
+{
+    return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_ACCELERATION, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
+double TraCICommandInterface::Vehicle::getDistanceTravelled()
+{
+    return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_DISTANCE, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
 double TraCICommandInterface::Vehicle::getCO2Emissions() const
 {
     return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_CO2EMISSION, RESPONSE_GET_VEHICLE_VARIABLE);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -494,6 +494,49 @@ void TraCICommandInterface::Vehicle::stopAt(std::string roadId, double pos, uint
     ASSERT(buf.eof());
 }
 
+std::pair<std::string, double> TraCICommandInterface::Vehicle::getLeader(const double distance)
+{
+    TraCIBuffer request = TraCIBuffer () << VAR_LEADER << nodeId << TYPE_DOUBLE << distance;
+    TraCIBuffer response = connection->query(CMD_GET_VEHICLE_VARIABLE, request);
+
+    uint8_t cmdLength;
+    response >> cmdLength;
+    if (cmdLength == 0) {
+        uint32_t cmdLengthX;
+        response >> cmdLengthX;
+    }
+    uint8_t responseId;
+    response >> responseId;
+    ASSERT(responseId == RESPONSE_GET_VEHICLE_VARIABLE);
+    uint8_t variableType;
+    response >> variableType;
+    ASSERT(variableType == VAR_LEADER);
+    uint32_t compoundSize;
+    response >> compoundSize;
+    uint8_t responseType;
+    response >> responseType; // I don't know what 1 means here, skipping
+    response >> responseType;
+    ASSERT(responseType == TYPE_COMPOUND);
+    uint32_t numElements;
+    response >> numElements;
+    ASSERT(numElements == 2);
+    uint8_t leaderType;
+    response >> leaderType;
+    ASSERT(leaderType == TYPE_STRING);
+    std::string leaderId;
+    response >> leaderId;
+    uint8_t distanceType;
+    response >> distanceType;
+    ASSERT(distanceType == TYPE_DOUBLE);
+    double distanceToLeader;
+    response >> distanceToLeader;
+
+    ASSERT(response.eof());
+
+    return std::make_pair(leaderId, distanceToLeader);
+}
+
+
 std::list<std::string> TraCICommandInterface::getTrafficlightIds()
 {
     return genericGetStringList(CMD_GET_TL_VARIABLE, "", ID_LIST, RESPONSE_GET_TL_VARIABLE);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -371,6 +371,11 @@ double TraCICommandInterface::Vehicle::getSpeed()
     return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_SPEED, RESPONSE_GET_VEHICLE_VARIABLE);
 }
 
+double TraCICommandInterface::Vehicle::getAngle()
+{
+    return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_ANGLE, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
 double TraCICommandInterface::Vehicle::getAcceleration()
 {
     return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_ACCELERATION, RESPONSE_GET_VEHICLE_VARIABLE);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -511,10 +511,10 @@ std::pair<std::string, double> TraCICommandInterface::Vehicle::getLeader(const d
     uint8_t variableType;
     response >> variableType;
     ASSERT(variableType == VAR_LEADER);
-    uint32_t compoundSize;
-    response >> compoundSize;
+    std::string rspNodeId;
+    response >> rspNodeId;
+    ASSERT(strcmp(rspNodeId.c_str(), nodeId.c_str()) == 0);
     uint8_t responseType;
-    response >> responseType; // I don't know what 1 means here, skipping
     response >> responseType;
     ASSERT(responseType == TYPE_COMPOUND);
     uint32_t numElements;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -160,6 +160,7 @@ public:
         double getAccel();
         double getDeccel();
         double getSpeed();
+        double getAngle();
         double getAcceleration();
         double getDistanceTravelled();
 

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -250,6 +250,8 @@ public:
          */
         double getAccumulatedWaitingTime() const;
 
+        std::pair<std::string, double> getLeader(const double distance);
+
     protected:
         TraCICommandInterface* traci;
         TraCIConnection* connection;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -159,6 +159,9 @@ public:
         double getHeight();
         double getAccel();
         double getDeccel();
+        double getSpeed();
+        double getAcceleration();
+        double getDistanceTravelled();
 
         void setParameter(const std::string& parameter, int value);
         void setParameter(const std::string& parameter, double value);

--- a/subprojects/veins_testsims/sim/veins_testsims/traci/README
+++ b/subprojects/veins_testsims/sim/veins_testsims/traci/README
@@ -1,5 +1,7 @@
 Veins smoke tests. Please ignore.
 
+To run this simulation, execute the script `sim/veins_testsims/traci/runall`.
+
 This simulation requires sumo-launchd to be started and listening for 
 connections on a TCP socket, e.g. using "~/src/veins/sumo-launchd.py -vv".
 

--- a/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
+++ b/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
@@ -99,7 +99,7 @@ sim-time-limit = 100s
 ##########################################################
 
 *.node[*].applType = "org.car2x.veins.subprojects.veins_testsims.traci.TraCITestApp"
-*.node[0].appl.testNumber = ${0..80}
+*.node[0].appl.testNumber = ${0..84}
 *.node[*].appl.testNumber = -1
 
 ##########################################################

--- a/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
+++ b/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
@@ -99,7 +99,7 @@ sim-time-limit = 100s
 ##########################################################
 
 *.node[*].applType = "org.car2x.veins.subprojects.veins_testsims.traci.TraCITestApp"
-*.node[0].appl.testNumber = ${0..84}
+*.node[0].appl.testNumber = ${0..85}
 *.node[*].appl.testNumber = -1
 
 ##########################################################

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -436,6 +436,31 @@ void TraCITestApp::handlePositionUpdate()
 
     if (testNumber == testCounter++) {
         if (t == 1) {
+            assertClose("(TraCICommandInterface::Vehicle::getAngle)", 90.0, traciVehicle->getAngle());
+        }
+    }
+
+    if (testNumber == testCounter++) {
+        if (t == 1) {
+            traciVehicle->setSpeed(0);
+            assertEqual("(TraCICommandInterface::Vehicle::getAcceleration) at t=1 should be 0", 0.0, traciVehicle->getAcceleration());
+        }
+        if (t == 2) {
+            assertClose("(TraCICommandInterface::Vehicle::getAcceleration) at t=2", -9.81, traciVehicle->getAcceleration());
+        }
+    }
+
+    if (testNumber == testCounter++) {
+        if (t == 0) {
+            assertEqual("(TraCICommandInterface::Vehicle::getDistanceTravelled) at t=0", 0.0, traciVehicle->getDistanceTravelled());
+        }
+        if (t == 10) {
+            assertClose("(TraCICommandInterface::Vehicle::getDistanceTravelled) at t=10", 272.5853340, traciVehicle->getDistanceTravelled());
+        }
+    }
+
+    if (testNumber == testCounter++) {
+        if (t == 1) {
             traciVehicle->changeVehicleRoute({"25", "28", "31", "34", "37", "40", "13", "44"});
         }
         if (t == 30) {

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -428,6 +428,12 @@ void TraCITestApp::handlePositionUpdate()
         }
     }
 
+    if (testNumber == testCounter++)  {
+        if (t == 1) {
+            assertClose("(TraCICommandInterface::Vehicle::getSpeed)", 31.0110309, traciVehicle->getSpeed());
+        }
+    }
+
     if (testNumber == testCounter++) {
         if (t == 1) {
             traciVehicle->changeVehicleRoute({"25", "28", "31", "34", "37", "40", "13", "44"});

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -319,6 +319,17 @@ void TraCITestApp::handlePositionUpdate()
     }
 
     if (testNumber == testCounter++) {
+        if (t == 6) { // both vehicles should be on the scene by now
+            auto pair0 = traci->vehicle("flow0.0").getLeader(1000);
+            auto pair1 = traci->vehicle("flow0.1").getLeader(1000);
+            assertEqual("((TraCICommandInterface::Vehicle::getLeader, 0.0) vehicle 0 leaderID", "", pair0.first);
+            assertClose("((TraCICommandInterface::Vehicle::getLeader, 0.0) vehicle 0 distance", -1.0, pair0.second);
+            assertEqual("((TraCICommandInterface::Vehicle::getLeader, 0.0) vehicle 1 leaderID", "flow0.0", pair1.first);
+            assertClose("((TraCICommandInterface::Vehicle::getLeader, 0.0) vehicle 1 distance", 146.4500273, pair1.second);
+        }
+    }
+
+    if (testNumber == testCounter++) {
         if (t == 1) {
             assertEqual("(TraCICommandInterface::Vehicle::getTypeId)", traciVehicle->getTypeId(), "vtype0");
         }


### PR DESCRIPTION
As part of my Master's thesis, I added some missing TraCI vehicle methods to TraCICommandInterface:
 * `getSpeed`
 * `getAngle`
 * `getAcceleration`
 * `getDistanceTravelled`
* `getLeader`

Submitting this PR in the hope that this saves someone else time in the future.
Please let me know if you need any changes or revisions!