### PR TITLE
Update DemoBaseApplLayer.cc

### DIFF
--- a/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
+++ b/src/veins/modules/application/ieee80211p/DemoBaseApplLayer.cc
@@ -117,7 +117,7 @@ simtime_t DemoBaseApplLayer::computeAsynchronousSendingTime(simtime_t interval, 
      * when alternate access is enabled in the MAC
      */
 
-    simtime_t randomOffset = dblrand() * beaconInterval;
+    simtime_t randomOffset = dblrand() * interval;
     simtime_t firstEvent;
     simtime_t switchingInterval = mac->getSwitchingInterval(); // usually 0.050s
     simtime_t nextCCH;


### PR DESCRIPTION
The parameter "interval" in the computeAsynchronousSendingTime method signature is never used inside that method.
Replacing "beaconInterval" with "interval" in the method likely preserves its original intended semantic and allows "wsaInterval" to be correctly used in the startService.