### PR TITLE
Additional TraCI commands

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIBuffer.h
+++ b/src/veins/modules/mobility/traci/TraCIBuffer.h
@@ -133,13 +133,13 @@ public:
 
     /**
      * @brief
-     * first read a Byte. Only if read value is 0, read requested data type.
+     * first read a Byte. Only if read value is 0 and EOF has not been reached, read requested data type.
      */
     template <typename T>
     T readByteOrFull()
     {
         uint8_t shortBuf = read<uint8_t>();
-        if (shortBuf > 0) {
+        if (shortBuf > 0 || eof()) {
             return shortBuf;
         }
         return read<T>();

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -250,6 +250,21 @@ std::list<std::string> TraCICommandInterface::getRouteIds()
     return genericGetStringList(CMD_GET_ROUTE_VARIABLE, "", ID_LIST, RESPONSE_GET_ROUTE_VARIABLE);
 }
 
+void TraCICommandInterface::addRoute(std::string routeId, const std::list<std::string> &edges)
+{
+    TraCIBuffer p;
+    p << static_cast<uint8_t>(ADD);
+    p << routeId;
+    p << static_cast<uint8_t>(TYPE_STRINGLIST);
+    p << static_cast<int32_t>(edges.size());
+    for (const std::string &edge : edges) {
+        p << edge;
+    }
+
+    TraCIBuffer buf = connection.query(CMD_SET_ROUTE_VARIABLE, p);
+    ASSERT(buf.eof());
+}
+
 std::list<std::string> TraCICommandInterface::getRoadIds()
 {
     return genericGetStringList(CMD_GET_EDGE_VARIABLE, "", ID_LIST, RESPONSE_GET_EDGE_VARIABLE);

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -455,6 +455,16 @@ double TraCICommandInterface::Vehicle::getAccumulatedWaitingTime() const
     return traci->genericGetDouble(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_WAITING_TIME_ACCUMULATED, RESPONSE_GET_VEHICLE_VARIABLE);
 }
 
+uint8_t TraCICommandInterface::Vehicle::getStopState() const
+{
+    return traci->genericGetInt(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_STOPSTATE, RESPONSE_GET_VEHICLE_VARIABLE);
+}
+
+bool TraCICommandInterface::Vehicle::isStopped() const
+{
+    return getStopState() & 0x1;
+}
+
 double TraCICommandInterface::getDistance(const Coord& p1, const Coord& p2, bool returnDrivingDistance)
 {
     uint8_t variable = DISTANCE_REQUEST;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -460,7 +460,7 @@ uint8_t TraCICommandInterface::Vehicle::getStopState() const
     return traci->genericGetInt(CMD_GET_VEHICLE_VARIABLE, nodeId, VAR_STOPSTATE, RESPONSE_GET_VEHICLE_VARIABLE);
 }
 
-bool TraCICommandInterface::Vehicle::isStopped() const
+bool TraCICommandInterface::Vehicle::isStopReached() const
 {
     return getStopState() & 0x1;
 }

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -1121,6 +1121,11 @@ double TraCICommandInterface::Lane::getMeanSpeed()
     return traci->genericGetDouble(CMD_GET_LANE_VARIABLE, laneId, LAST_STEP_MEAN_SPEED, RESPONSE_GET_LANE_VARIABLE);
 }
 
+double TraCICommandInterface::Lane::getWidth()
+{
+    return traci->genericGetDouble(CMD_GET_LANE_VARIABLE, laneId, VAR_WIDTH, RESPONSE_GET_LANE_VARIABLE);
+}
+
 void TraCICommandInterface::Lane::setDisallowed(std::list<std::string> disallowedClasses)
 {
     uint8_t variableId = LANE_DISALLOWED;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -1156,6 +1156,11 @@ Coord TraCICommandInterface::Junction::getPosition()
     return traci->genericGetCoord(CMD_GET_JUNCTION_VARIABLE, junctionId, VAR_POSITION, RESPONSE_GET_JUNCTION_VARIABLE);
 }
 
+std::list<Coord> TraCICommandInterface::Junction::getShape()
+{
+    return traci->genericGetCoordList(CMD_GET_JUNCTION_VARIABLE, junctionId, VAR_SHAPE, RESPONSE_GET_JUNCTION_VARIABLE);
+}
+
 bool TraCICommandInterface::addVehicle(std::string vehicleId, std::string vehicleTypeId, std::string routeId, simtime_t emitTime_st, double emitPosition, double emitSpeed, int8_t emitLane)
 {
     TraCIConnection::Result result;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -465,6 +465,18 @@ bool TraCICommandInterface::Vehicle::isStopped() const
     return getStopState() & 0x1;
 }
 
+void TraCICommandInterface::Vehicle::changeTarget(const std::string &newTarget) const
+{
+    TraCIBuffer p;
+    p << static_cast<uint8_t>(CMD_CHANGETARGET);
+    p << nodeId;
+    p << static_cast<uint8_t>(TYPE_STRING);
+    p << newTarget;
+
+    TraCIBuffer buf = traci->connection.query(CMD_SET_VEHICLE_VARIABLE, p);
+    ASSERT(buf.eof());
+}
+
 double TraCICommandInterface::getDistance(const Coord& p1, const Coord& p2, bool returnDrivingDistance)
 {
     uint8_t variable = DISTANCE_REQUEST;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -452,6 +452,7 @@ public:
 
     // Route methods
     std::list<std::string> getRouteIds();
+    void addRoute(std::string routeId, const std::list<std::string> &edges);
     class VEINS_API Route {
     public:
         Route(TraCICommandInterface* traci, std::string routeId)

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -250,6 +250,26 @@ public:
          */
         double getAccumulatedWaitingTime() const;
 
+        /**
+         * Get the vehicle's stop state which carries information about whether it is currently stopping and in which context.
+         *
+         * @return the stop state which is a bit field defined as follows:
+         *     1 * stopped
+         * +   2 * parking
+         * +   4 * triggered
+         * +   8 * containerTriggered
+         * +  16 * atBusStop
+         * +  32 * atContainerStop
+         * +  64 * atChargingStation
+         * + 128 * atParkingArea
+         */
+        uint8_t getStopState() const;
+
+        /**
+         * Get whether the vehicle is currently stopped.
+         */
+        bool isStopped() const;
+
         std::pair<std::string, double> getLeader(const double distance);
 
         std::vector<std::tuple<std::string, int, double, char>> getNextTls();

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -465,6 +465,7 @@ public:
         }
 
         Coord getPosition();
+        std::list<Coord> getShape();
 
     protected:
         TraCICommandInterface* traci;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -329,6 +329,7 @@ public:
         double getLength();
         double getMaxSpeed();
         double getMeanSpeed();
+        double getWidth();
         void setDisallowed(std::list<std::string> disallowedClasses);
 
     protected:

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -266,9 +266,9 @@ public:
         uint8_t getStopState() const;
 
         /**
-         * Get whether the vehicle is currently stopped.
+         * Get whether the vehicle is currently stopping at a scheduled stop (e.g. a bus stop or after using stopAt).
          */
-        bool isStopped() const;
+        bool isStopReached() const;
 
         /**
          * Sets the vehicle's current destination edge, causing its route to be rebuilt.

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -270,6 +270,11 @@ public:
          */
         bool isStopped() const;
 
+        /**
+         * Sets the vehicle's current destination edge, causing its route to be rebuilt.
+         */
+        void changeTarget(const std::string &newTarget) const;
+
         std::pair<std::string, double> getLeader(const double distance);
 
         std::vector<std::tuple<std::string, int, double, char>> getNextTls();

--- a/subprojects/veins_testsims/sim/veins_testsims/traci/README
+++ b/subprojects/veins_testsims/sim/veins_testsims/traci/README
@@ -2,6 +2,6 @@ Veins smoke tests. Please ignore.
 
 To run this simulation, execute the script `sim/veins_testsims/traci/runall`.
 
-This simulation requires sumo-launchd to be started and listening for 
-connections on a TCP socket, e.g. using "~/src/veins/sumo-launchd.py -vv".
+This simulation requires sumo-launchd to be started and listening for
+connections on a TCP socket, e.g. using "~/src/veins/bin/veins_launchd -vv".
 

--- a/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
+++ b/subprojects/veins_testsims/sim/veins_testsims/traci/omnetpp.ini
@@ -99,7 +99,7 @@ sim-time-limit = 100s
 ##########################################################
 
 *.node[*].applType = "org.car2x.veins.subprojects.veins_testsims.traci.TraCITestApp"
-*.node[0].appl.testNumber = ${0..86}
+*.node[0].appl.testNumber = ${0..91}
 *.node[*].appl.testNumber = -1
 
 ##########################################################

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -711,6 +711,23 @@ void TraCITestApp::handlePositionUpdate()
         }
     }
 
+    if (testNumber == testCounter++) {
+        if (t == 1) {
+            auto routes_before = traci->getRouteIds();
+            assertEqual("(TraCICommandInterface::addRoute) number of routes is 1 before adding", size_t(1), routes_before.size());
+
+            traci->addRoute("route1", {"2", "27", "30"});
+
+            auto routes_after = traci->getRouteIds();
+            assertEqual("(TraCICommandInterface::addRoute) number of routes is 2 after adding", size_t(2), routes_after.size());
+            assertTrue("(TraCICommandInterface::addRoute) route list contains route1 after adding", std::find(routes_after.begin(), routes_after.end(), "route1") != routes_after.end());
+
+            auto roads = traci->route("route1").getRoadIds();
+            assertEqual("(TraCICommandInterface::Route::addRoute) road ids of new route has 3 entries", size_t(3), roads.size());
+            assertEqual("(TraCICommandInterface::Route::addRoute) road ids of new route starts with 2", "2", *roads.begin());
+        }
+    }
+
     //
     // TraCICommandInterface::Road
     //

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -337,11 +337,11 @@ void TraCITestApp::handlePositionUpdate()
             traci->vehicle(mobility->getExternalId()).stopAt("43", 20, 0, 10, 30);
         }
         if (t == 2) {
-            assertFalse("(TraCICommandInterface::Vehicle::isStopped) vehicle is not stopped", traci->vehicle(mobility->getExternalId()).isStopped());
+            assertFalse("(TraCICommandInterface::Vehicle::isStopped) vehicle is not stopped", traci->vehicle(mobility->getExternalId()).isStopReached());
         }
         if (t == 30) {
             assertTrue("(TraCICommandInterface::Vehicle::isStopped) vehicle is at 43", roadId == "43");
-            assertTrue("(TraCICommandInterface::Vehicle::isStopped) vehicle is stopped", traci->vehicle(mobility->getExternalId()).isStopped());
+            assertTrue("(TraCICommandInterface::Vehicle::isStopped) vehicle is stopped", traci->vehicle(mobility->getExternalId()).isStopReached());
         }
     }
 

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -673,8 +673,18 @@ void TraCITestApp::handlePositionUpdate()
             std::list<std::string> junctions = traci->getJunctionIds();
             assertTrue("(TraCICommandInterface::Junction::getJunctionIds) returns test junction", std::find(junctions.begin(), junctions.end(), "1") != junctions.end());
             Coord pos = traci->junction("1").getPosition();
-            assertClose("(TraCICommandInterface::Junction::getPosition) shape x coordinate is correct", 25.0, pos.x);
-            assertClose("(TraCICommandInterface::Junction::getPosition) shape y coordinate is correct", 75.0, pos.y);
+            assertClose("(TraCICommandInterface::Junction::getPosition) junction x coordinate is correct", 25.0, pos.x);
+            assertClose("(TraCICommandInterface::Junction::getPosition) junction y coordinate is correct", 75.0, pos.y);
+        }
+    }
+
+    if (testNumber == testCounter++) {
+        if (t == 30) {
+            auto shape = traci->junction("10").getShape();
+            Coord shape_front_coord = shape.front();
+
+            assertClose("(TraCICommandInterface::Junction::getShape) shape's first x coordinate is correct", 321., floor(shape_front_coord.x));
+            assertClose("(TraCICommandInterface::Junction::getShape) shape's first y coordinate is correct", 73., floor(shape_front_coord.y));
         }
     }
 

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -312,6 +312,18 @@ void TraCITestApp::handlePositionUpdate()
 
     if (testNumber == testCounter++) {
         if (t == 1) {
+            traciVehicle->changeTarget("39");
+        }
+        if (t == 25) {
+            assertTrue("(TraCICommandInterface::Vehicle::changeTarget, -1) vehicle took 39", visitedEdges.find("39") != visitedEdges.end());
+        }
+        if (t == 26) {
+            assertTrue("(TraCICommandInterface::Vehicle::changeTarget, -1) vehicle should have already despawed after visiting 39", false);
+        }
+    }
+
+    if (testNumber == testCounter++) {
+        if (t == 1) {
             traci->vehicle(mobility->getExternalId()).stopAt("43", 20, 0, 10, 30);
         }
         if (t == 30) {

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -690,6 +690,13 @@ void TraCITestApp::handlePositionUpdate()
         }
     }
 
+    if (testNumber == testCounter++) {
+        if (t == 30) {
+            double width = traci->lane("10_0").getWidth();
+            assertClose("(TraCICommandInterface::Lane::getWidth) lane width is correct", 3.2, width);
+        }
+    }
+
     //
     // TraCICommandInterface::Polygon
     //

--- a/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
+++ b/subprojects/veins_testsims/src/veins_testsims/traci/TraCITestApp.cc
@@ -333,6 +333,19 @@ void TraCITestApp::handlePositionUpdate()
     }
 
     if (testNumber == testCounter++) {
+        if (t == 1) {
+            traci->vehicle(mobility->getExternalId()).stopAt("43", 20, 0, 10, 30);
+        }
+        if (t == 2) {
+            assertFalse("(TraCICommandInterface::Vehicle::isStopped) vehicle is not stopped", traci->vehicle(mobility->getExternalId()).isStopped());
+        }
+        if (t == 30) {
+            assertTrue("(TraCICommandInterface::Vehicle::isStopped) vehicle is at 43", roadId == "43");
+            assertTrue("(TraCICommandInterface::Vehicle::isStopped) vehicle is stopped", traci->vehicle(mobility->getExternalId()).isStopped());
+        }
+    }
+
+    if (testNumber == testCounter++) {
         if (t == 6) { // both vehicles should be on the scene by now
             auto pair0 = traci->vehicle("flow0.0").getLeader(1000);
             auto pair1 = traci->vehicle("flow0.1").getLeader(1000);


### PR DESCRIPTION
This pull request implements a selection of additional TraCI commands I have found useful during my master thesis simulating delivery traffic using SUMO in conjunction with Veins.

- addRoute(): Allows creating a new route with the given edges at runtime (Useful for inserting vehicles at arbitrary positions in the network when no suitable route exists yet. This can be combined with Vehicle::changeTarget to only specify the insertion edge and let SUMO plan the rest of the route for you.)
- Vehicle::changeTarget(): Allow setting a new destination edge which will cause a new route to be calculated.
- Vehicle::getStopState() and Vehicle::isStopped(): Returns whether a vehicle is currently stopped and for what purpose.
- Lane::getWidth(): Get the width of a lane
- Junction::getShape(): Get the shape of a junction

This pull request also contains a change to TraCIBuffer::readByteOrFull to allow handling zero-length polygons, e.g. when requesting the shape of a junction which has no shape assigned.