### PR TITLE
Adding workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,85 @@
+name: linux-build
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '42 3 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      OMNET_VERSION: 5.6.2
+    strategy:
+      fail-fast: false
+      matrix:
+        sumo_build: [ubuntu, ppa, nightly]
+
+    steps:
+    - name: Cloning Veins
+      uses: actions/checkout@v2
+      with:
+        path: src/veins
+
+    - name: Cloning OMNeT++
+      uses: actions/checkout@v2
+      with:
+        repository: omnetpp/omnetpp
+        ref: omnetpp-${{ env.OMNET_VERSION }}
+        path: src/omnetpp
+
+    - name: Preparing Build System
+      run: |
+        if [[ "${{ matrix.sumo_build }}" == "ppa" ]]; then sudo add-apt-repository ppa:sumo/stable; fi
+        sudo apt-get update
+        sudo apt-get install build-essential gcc g++ bison flex perl python3 libxml2-dev zlib1g-dev default-jre doxygen graphviz
+
+    - name: Installing SUMO from repo
+      if: matrix.sumo_build != 'nightly'
+      run: |
+        sudo apt-get install sumo sumo-tools
+        # SUMO_HOME seems to be unnecessary for veins but we stay to the general pattern
+        echo "SUMO_HOME=/usr/share/sumo" >> $GITHUB_ENV
+
+    - name: Installing SUMO from PyPI
+      if: matrix.sumo_build == 'nightly'
+      run: |
+        python -m pip install --index-url https://test.pypi.org/simple/ eclipse-sumo
+        # SUMO_HOME seems to be unnecessary for veins but we stay to the general pattern
+        python -c "import sumo; print('SUMO_HOME=' + sumo.SUMO_HOME)" >> $GITHUB_ENV
+
+    # it might be unnecessary to add $SUMO_HOME/bin here but better safe than sorry
+    - name: Adapting PATH
+      run: |
+        echo "PATH=$PWD/src/omnetpp/bin:$SUMO_HOME/bin:$PATH" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+
+    - name: Building OMNeT
+      run: |
+        cd src/omnetpp
+        cp configure.user.dist configure.user
+        ./configure WITH_TKENV=no WITH_QTENV=no WITH_OSG=no WITH_OSGEARTH=no
+        make -j4
+
+    - name: Building Veins
+      run: |
+        cd src/veins
+        ./configure
+        make -j4
+
+    - name: Running Veins Test
+      run: |
+        cd src/veins/examples/veins
+        echo $SUMO_HOME; sumo  # just to check
+        ../../bin/veins_launchd -vv --daemon -L veins_launchd.log
+        ./run -u Cmdenv
+
+    - name: Upload Test log
+      if: ${{ always() }}
+#      if: ${{ failure() }}
+      uses: actions/upload-artifact@v2
+      with:
+          name: veins-${{ matrix.sumo_build }}.log
+          path: |
+            src/veins/examples/veins/veins_launchd.log


### PR DESCRIPTION
This adds a github actions workflow building omnet and veins and running with three versions of sumo:

- the plain ubuntu sumo (currently 1.4.0)
- the ppa version (latest release, currently 1.9.1 and broken for veins)
- the nightly build from the Python package index

The workflow runs on all pushes and PRs to the veins repo and every night to check changes in SUMO. 

Possible optimizations include:

- in the scheduled nightly run only test the nightly sumo
- cache the omnet build results