### PR TITLE
Improved TimerManager

### DIFF
--- a/src/veins/modules/utility/TimerManager.cc
+++ b/src/veins/modules/utility/TimerManager.cc
@@ -39,6 +39,13 @@ struct veins::TimerMessage : public omnetpp::cMessage {
 TimerSpecification::TimerSpecification(std::function<void()> callback)
     : start_mode_(StartMode::immediate)
     , end_mode_(EndMode::open)
+    , callback_([callback](TimerManager::TimerHandle) { callback(); })
+{
+}
+
+TimerSpecification::TimerSpecification(std::function<void(TimerManager::TimerHandle)> callback)
+    : start_mode_(StartMode::immediate)
+    , end_mode_(EndMode::open)
     , callback_(callback)
 {
 }
@@ -181,7 +188,7 @@ bool TimerManager::handleMessage(omnetpp::cMessage* message)
     }
     ASSERT(timer->second.valid() && timer->second.validOccurence(simTime()));
 
-    timer->second.callback_();
+    timer->second.callback_(timer->first->getId());
 
     if (timers_.find(timerMessage) != timers_.end()) { // confirm that the timer has not been cancelled during the callback
         const auto nextEvent = timer->second.next();

--- a/src/veins/modules/utility/TimerManager.h
+++ b/src/veins/modules/utility/TimerManager.h
@@ -70,6 +70,21 @@ public:
     TimerSpecification(std::function<void()> callback);
 
     /**
+     * Create a new TimerSpecification.
+     *
+     * The created timer is invalid, an interval is missing for it to be usable.
+     * By default, the timer starts running immediately and triggers first after the first time after the interval.
+     * After that, it will continue to run until the simulation ends, calling the callback after the interval has elapsed.
+     * In order to create a timer, this needs to be passed to TimerManager::create.
+     *
+     * @param callback The callback which is executed when the timer is triggered. It will be passed the timer's handle that
+     *		can be used to cancel the timer.
+     *
+     * @see TimerManager
+     */
+    TimerSpecification(std::function<void(long handle)> callback);
+
+    /**
      * Set the period between two timer occurences.
      */
     TimerSpecification& interval(omnetpp::simtime_t interval);
@@ -195,15 +210,15 @@ private:
     EndMode end_mode_; ///< Interpretation of end time._
     unsigned end_count_; ///< Number of repetitions of the timer. Only valid when end_mode_ == repetition.
     omnetpp::simtime_t end_time_; ///< Last possible occurence of the timer. Only valid when end_mode_ != repetition.
-    std::function<omnetpp::simtime_t()> period_generator_; ///< Generator for time between events.
-    std::function<void()> callback_; ///< The function to be called when the Timer is triggered.
+    std::function<omnetpp::simtime_t()> period_generator_; ///< Time between events.
+    std::function<void(long)> callback_; ///< The function to be called when the Timer is triggered.
 };
 
 class VEINS_API TimerManager {
 private:
 public:
-    using TimerHandle = long;
     using TimerList = std::map<TimerMessage*, TimerSpecification>;
+    using TimerHandle = long;
 
     TimerManager(omnetpp::cSimpleModule* parent);
 

--- a/subprojects/veins_testsims/opp_tests/timermanager/cancel.test
+++ b/subprojects/veins_testsims/opp_tests/timermanager/cancel.test
@@ -1,0 +1,74 @@
+//
+// Copyright (C) 2021 Max Schettler <schettler@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+%description
+Ensure timers are called at appropriate times.
+
+%file: test.ned
+
+simple Module {}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/TimerManager.h"
+
+namespace @TESTNAME@ {
+
+class Module : public cSimpleModule {
+public:
+    void initialize(int stage) override;
+    void handleMessage(cMessage* msg) override { timers.handleMessage(msg); }
+protected:
+    veins::TimerManager timers{this};
+};
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    auto handle = timers.create(
+        veins::TimerSpecification([this]() { EV << "timer 1 called at " << simTime() << std::endl; })
+        .interval(1).repetitions(3)
+    );
+
+    timers.create(
+        veins::TimerSpecification([this, handle]() {  timers.cancel(handle); })
+        .oneshotAt(2.5)
+    );
+
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+timer 1 called at 1
+%contains: stdout
+timer 1 called at 2
+%not-contains: stdout
+timer 1 called at 3

--- a/subprojects/veins_testsims/opp_tests/timermanager/cancel.test
+++ b/subprojects/veins_testsims/opp_tests/timermanager/cancel.test
@@ -62,6 +62,13 @@ void Module::initialize(int stage)
         .oneshotAt(2.5)
     );
 
+    timers.create(
+        veins::TimerSpecification([this](veins::TimerManager::TimerHandle handle) {
+            timers.cancel(handle);
+            EV << "timer 2 called at " << simTime() << std::endl;
+        })
+        .interval(1).repetitions(3)
+    );
 }
 
 } // namespace @TESTNAME@
@@ -72,3 +79,10 @@ timer 1 called at 1
 timer 1 called at 2
 %not-contains: stdout
 timer 1 called at 3
+
+%contains: stdout
+timer 2 called at 1
+%not-contains: stdout
+timer 2 called at 2
+%not-contains: stdout
+timer 2 called at 3

--- a/subprojects/veins_testsims/opp_tests/timermanager/end.test
+++ b/subprojects/veins_testsims/opp_tests/timermanager/end.test
@@ -1,0 +1,124 @@
+//
+// Copyright (C) 2021 Max Schettler <schettler@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+%description
+Ensure timers are called at appropriate times.
+
+%file: test.ned
+
+simple Module {}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/TimerManager.h"
+
+namespace @TESTNAME@ {
+
+class Module : public cSimpleModule {
+public:
+    void initialize(int stage) override;
+    void handleMessage(cMessage* msg) override { timers.handleMessage(msg); }
+protected:
+    void createRelative();
+
+    veins::TimerManager timers{this};
+};
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    timers.create(
+        veins::TimerSpecification([this]() { createRelative(); })
+        .oneshotAt(2)
+    );
+
+    getSimulation()->setSimulationTimeLimit(1e6);
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "openEnd called at " << simTime() << std::endl; })
+        .interval(1000)
+    );
+
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "repetitions called at " << simTime() << std::endl; })
+        .interval(1).repetitions(3)
+    );
+
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "absoluteEnd called at " << simTime() << std::endl; })
+        .interval(1).absoluteEnd(5)
+    );
+}
+
+void Module::createRelative() {
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "relativeEnd called at " << simTime() << std::endl; })
+        .interval(1).relativeEnd(4)
+    );
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+openEnd called at 30
+%contains: stdout
+openEnd called at 535000
+
+%contains: stdout
+repetitions called at 1
+%contains: stdout
+repetitions called at 2
+%contains: stdout
+repetitions called at 3
+%not-contains: stdout
+repetitions called at 4
+
+%contains: stdout
+absoluteEnd called at 1
+%contains: stdout
+absoluteEnd called at 2
+%contains: stdout
+absoluteEnd called at 3
+%contains: stdout
+absoluteEnd called at 4
+%contains: stdout
+absoluteEnd called at 5
+%not-contains: stdout
+absoluteEnd called at 6
+
+%contains: stdout
+relativeEnd called at 3
+%contains: stdout
+relativeEnd called at 4
+%contains: stdout
+relativeEnd called at 5
+%contains: stdout
+relativeEnd called at 6
+%not-contains: stdout
+relativeEnd called at 7

--- a/subprojects/veins_testsims/opp_tests/timermanager/interval.test
+++ b/subprojects/veins_testsims/opp_tests/timermanager/interval.test
@@ -61,6 +61,12 @@ void Module::initialize(int stage)
         veins::TimerSpecification([this]() { EV << "timer 2 called at " << simTime() << std::endl; })
         .interval(2.8).repetitions(2)
     );
+
+    int i = 1;
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "timer 3 called at " << simTime() << std::endl; })
+        .interval([i]() mutable { return i <= 3 ? i++ : -1;})
+    );
 }
 
 } // namespace @TESTNAME@
@@ -76,3 +82,12 @@ timer 1 called at 3
 timer 2 called at 2.8
 %contains: stdout
 timer 2 called at 5.6
+
+%contains: stdout
+timer 3 called at 1
+%contains: stdout
+timer 3 called at 3
+%contains: stdout
+timer 3 called at 6
+%not-contains: stdout
+timer 3 called at 10

--- a/subprojects/veins_testsims/opp_tests/timermanager/interval.test
+++ b/subprojects/veins_testsims/opp_tests/timermanager/interval.test
@@ -1,0 +1,78 @@
+//
+// Copyright (C) 2021 Max Schettler <schettler@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+%description
+Ensure timers are called at appropriate times.
+
+%file: test.ned
+
+simple Module {}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/TimerManager.h"
+
+namespace @TESTNAME@ {
+
+class Module : public cSimpleModule {
+public:
+    void initialize(int stage) override;
+    void handleMessage(cMessage* msg) override { timers.handleMessage(msg); }
+protected:
+    veins::TimerManager timers{this};
+};
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "timer 1 called at " << simTime() << std::endl; })
+        .interval(1).repetitions(3)
+    );
+
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "timer 2 called at " << simTime() << std::endl; })
+        .interval(2.8).repetitions(2)
+    );
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+timer 1 called at 1
+%contains: stdout
+timer 1 called at 2
+%contains: stdout
+timer 1 called at 3
+
+%contains: stdout
+timer 2 called at 2.8
+%contains: stdout
+timer 2 called at 5.6

--- a/subprojects/veins_testsims/opp_tests/timermanager/oneshot.test
+++ b/subprojects/veins_testsims/opp_tests/timermanager/oneshot.test
@@ -1,0 +1,85 @@
+//
+// Copyright (C) 2021 Max Schettler <schettler@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+%description
+Ensure timers are called at appropriate times.
+
+%file: test.ned
+
+simple Module {}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/TimerManager.h"
+
+namespace @TESTNAME@ {
+
+class Module : public cSimpleModule {
+public:
+    void initialize(int stage) override;
+    void handleMessage(cMessage* msg) override { timers.handleMessage(msg); }
+protected:
+    void createRelative();
+
+    veins::TimerManager timers{this};
+};
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    timers.create(
+        veins::TimerSpecification([this]() { createRelative(); })
+        .oneshotAt(2)
+    );
+
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "oneshotAt called at " << simTime() << std::endl; })
+        .oneshotAt(3)
+    );
+}
+
+void Module::createRelative() {
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "oneshotIn called at " << simTime() << std::endl; })
+        .oneshotIn(3)
+    );
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+oneshotAt called at 3
+%not-contains-regex: stdout
+^oneshotAt called at [^3]$
+
+%contains: stdout
+oneshotIn called at 5
+%not-contains-regex: stdout
+^oneshotIn called at [^5]$

--- a/subprojects/veins_testsims/opp_tests/timermanager/runtest.sh
+++ b/subprojects/veins_testsims/opp_tests/timermanager/runtest.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright (C) 2018-2019 Dominik S. Buse <buse@ccs-labs.org>
+#
+# Documentation for these modules is at http://veins.car2x.org/
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+set -e
+
+TESTS="*.test"
+VEINS_PATH="../../../../../src/"
+EXTRA_CFLAGS="-I$VEINS_PATH -L$VEINS_PATH -lveins\$(D)"
+
+# ensure the working dir is ready
+mkdir -p work
+
+# generate test files
+opp_test gen -v $TESTS
+
+# build test files
+(cd work; opp_makemake -f --deep -o work $EXTRA_CFLAGS ; make -j4 MODE=debug)
+
+# run tests
+opp_test run -v -p work_dbg $TESTS

--- a/subprojects/veins_testsims/opp_tests/timermanager/start.test
+++ b/subprojects/veins_testsims/opp_tests/timermanager/start.test
@@ -1,0 +1,87 @@
+//
+// Copyright (C) 2021 Max Schettler <schettler@ccs-labs.org>
+//
+// Documentation for these modules is at http://veins.car2x.org/
+//
+// SPDX-License-Identifier: GPL-2.0-or-later
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+%description
+Ensure timers are called at appropriate times.
+
+%file: test.ned
+
+simple Module {}
+
+network Test
+{
+    submodules:
+        node: Module;
+}
+
+
+%file: test.cc
+#include "veins/veins.h"
+#include "veins/modules/utility/TimerManager.h"
+
+namespace @TESTNAME@ {
+
+class Module : public cSimpleModule {
+public:
+    void initialize(int stage) override;
+    void handleMessage(cMessage* msg) override { timers.handleMessage(msg); }
+protected:
+    void createRelative();
+
+    veins::TimerManager timers{this};
+};
+
+Define_Module(Module);
+
+void Module::initialize(int stage)
+{
+    timers.create(
+        veins::TimerSpecification([this]() { createRelative(); })
+        .oneshotAt(2)
+    );
+
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "absoluteStart called at " << simTime() << std::endl; })
+        .absoluteStart(3).interval(1).repetitions(1)
+    );
+
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "immediate called at " << simTime() << std::endl; })
+        .interval(1).repetitions(1)
+    );
+}
+
+void Module::createRelative() {
+    timers.create(
+        veins::TimerSpecification([this]() { EV << "relativeStart called at " << simTime() << std::endl; })
+        .relativeStart(3).interval(1).repetitions(1)
+    );
+}
+
+} // namespace @TESTNAME@
+
+%contains: stdout
+absoluteStart called at 3
+%contains: stdout
+relativeStart called at 5
+%contains: stdout
+immediate called at 1


### PR DESCRIPTION
This PR introduces multiple changes:
- add tests for the `TimerManager`
- add the possiblity to define a timers' interval by a functor that is called whenever it is rescheduled. This allows for dynamic timer intervals
- add a second callback option that always passes in the corresponding timers' handle. This makes it easier to cancel timers: From within the timer this is now possible without storing the handle manually.