### PR TITLE
Bugfix: missing parameter. Features: multiple obstacle controllers and new TraCI API

### DIFF
--- a/src/veins/modules/mobility/traci/TraCICommandInterface.cc
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.cc
@@ -492,6 +492,38 @@ void TraCICommandInterface::Vehicle::changeTarget(const std::string& newTarget) 
     ASSERT(buf.eof());
 }
 
+double TraCICommandInterface::getDistanceRoad(std::string e1, double p1, std::string e2, double p2, bool returnDrivingDistance)
+{
+    uint8_t variable = DISTANCE_REQUEST;
+    std::string simId = "sim0";
+    uint8_t variableType = TYPE_COMPOUND;
+    int32_t count = 3;
+    uint8_t dType = static_cast<uint8_t>(returnDrivingDistance ? REQUEST_DRIVINGDIST : REQUEST_AIRDIST);
+
+    TraCIBuffer buf = connection.query(CMD_GET_SIM_VARIABLE, TraCIBuffer() << variable << simId << variableType << count << static_cast<uint8_t>(POSITION_ROADMAP) << e1 << p1 << static_cast<uint8_t>(0) << static_cast<uint8_t>(POSITION_ROADMAP) << e2 << p2 << static_cast<uint8_t>(0) << dType);
+
+    uint8_t cmdLength_resp;
+    buf >> cmdLength_resp;
+    uint8_t commandId_resp;
+    buf >> commandId_resp;
+    ASSERT(commandId_resp == RESPONSE_GET_SIM_VARIABLE);
+    uint8_t variableId_resp;
+    buf >> variableId_resp;
+    ASSERT(variableId_resp == variable);
+    std::string simId_resp;
+    buf >> simId_resp;
+    ASSERT(simId_resp == simId);
+    uint8_t typeId_resp;
+    buf >> typeId_resp;
+    ASSERT(typeId_resp == TYPE_DOUBLE);
+    double distance;
+    buf >> distance;
+
+    ASSERT(buf.eof());
+
+    return distance;
+}
+
 double TraCICommandInterface::getDistance(const Coord& p1, const Coord& p2, bool returnDrivingDistance)
 {
     uint8_t variable = DISTANCE_REQUEST;

--- a/src/veins/modules/mobility/traci/TraCICommandInterface.h
+++ b/src/veins/modules/mobility/traci/TraCICommandInterface.h
@@ -112,6 +112,19 @@ public:
      */
     double getDistance(const Coord& position1, const Coord& position2, bool returnDrivingDistance);
 
+    /**
+     * Reads two positions on the road network and an indicator whether the air or the driving distance shall be computed. Returns the according distance.
+     *
+     * @param e1 id of first edge
+     * @param p1 position along first edge
+     * @param e2 id of second edge
+     * @param p2 position along second edge
+     * @param returnDrivingDistance whether to return the driving distance or the air distance
+     * @return the distance between the two positions
+     *
+     */
+    double getDistanceRoad(std::string e1, double p1, std::string e2, double p2, bool returnDrivingDistance);
+
     // Vehicle methods
     /**
      * @brief Adds a vehicle to the simulation.

--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.ned
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerForker.ned
@@ -42,5 +42,7 @@ simple TraCIScenarioManagerForker extends TraCIScenarioManager
         string command = default("sumo"); // substitution for $command parameter
         string configFile = default("my.sumo.cfg"); // substitution for $configFile parameter
         port = default(-1);  // substitution for $port parameter (-1: automatic)
+        int order = default(-1); // specific position in the multi-client execution order of the TraCI server to request upon connecting (-1: do not request a position)
+        bool ignoreUnknownSubscriptionResults = default(false); // whether to (try and) ignore any subscription result we did not request (but another client might have)
 }
 


### PR DESCRIPTION
This PR improve the current code base by:
- Fixing a bug introduced in 484169eef24085b244bddff2facdfc958ef20c19: the commit added two new parameters to `TraCIScenarioManager.ned` but not to `TraCIScenarioManagerForker.ned` causing the latter to be unusable;
- Enabling multiple building obstacle controllers: this can be useful when using heterogeneous communication technologies that both need the `SimpleObstacleShadowing` model;
- Adding a new TraCI API: adds the `getDistanceRoad` API to obtain the driving distance between two positions on two edges.