### PR TITLE
Adding Total Vehicles number

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.cc
@@ -277,6 +277,7 @@ void TraCIScenarioManager::initialize(int stage)
     hosts.clear();
     subscribedVehicles.clear();
     trafficLights.clear();
+    vehiclesTotalCount = 0;
     activeVehicleCount = 0;
     parkingVehicleCount = 0;
     drivingVehicleCount = 0;
@@ -796,7 +797,7 @@ void TraCIScenarioManager::processSimSubscription(std::string objectId, TraCIBuf
                 buf >> idstring;
                 // adding modules is handled on the fly when entering/leaving the ROI
             }
-
+            vehiclesTotalCount += count;
             activeVehicleCount += count;
             drivingVehicleCount += count;
         }

--- a/src/veins/modules/mobility/traci/TraCIScenarioManager.h
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManager.h
@@ -155,7 +155,8 @@ protected:
     std::set<std::string> unEquippedHosts;
     std::set<std::string> subscribedVehicles; /**< all vehicles we have already subscribed to */
     std::map<std::string, cModule*> trafficLights; /**< vector of all traffic lights managed by us */
-    uint32_t activeVehicleCount; /**< number of vehicles, be it parking or driving **/
+    uint32_t vehiclesTotalCount; /**< number of total vehicles */
+    uint32_t activeVehicleCount; /**< number of vehicles, be it parking or driving */
     uint32_t parkingVehicleCount; /**< number of parking vehicles, derived from parking start/end events */
     uint32_t drivingVehicleCount; /**< number of driving, as reported by sumo */
     bool autoShutdownTriggered;


### PR DESCRIPTION
Adding **vehiclesTotalCount** Variable in **TraCIScenarioManager**. Allowing easier way to record total number of entered vehicles in the analysis.
Cor

After some searching in INET framework, I didn't find a direct way to retrieve total number of vehicles who entered simulation so I decided to use this way myself and wanted to contribute it, Also feel free to correct me if there is any misunderstanding, I'm still exploring and learning this package and I will be more than happy to help.

