### PR TITLE
Improve baseDir default behaviour

### DIFF
--- a/src/veins/modules/mobility/traci/TraCIScenarioManagerLaunchd.cc
+++ b/src/veins/modules/mobility/traci/TraCIScenarioManagerLaunchd.cc
@@ -58,8 +58,18 @@ void TraCIScenarioManagerLaunchd::initialize(int stage)
     seed = par("seed");
     cXMLElementList basedir_nodes = launchConfig->getElementsByTagName("basedir");
     if (basedir_nodes.size() == 0) {
-        // default basedir is where current network file was loaded from
-        std::string basedir = cSimulation::getActiveSimulation()->getEnvir()->getConfig()->getConfigEntry("network").getBaseDirectory();
+        // set default basedir to where launchConfig is located
+        std::string basedir = launchConfig->getSourceLocation();
+        if (!basedir.empty()) {
+            // Cut the filename from the path
+            size_t pos = basedir.find_last_of("/\\");
+            if (pos != std::string::npos) basedir = basedir.substr(0, pos);
+            else basedir.clear(); // clear basedir on invalid filename
+        }
+        // alternative basedir is where current network file was loaded from
+        if(basedir.empty()){
+            basedir = cSimulation::getActiveSimulation()->getEnvir()->getConfig()->getConfigEntry("network").getBaseDirectory();
+        }
         cXMLElement* basedir_node = new cXMLElement("basedir", __FILE__, launchConfig);
         basedir_node->setAttribute("path", basedir.c_str());
         launchConfig->appendChild(basedir_node);


### PR DESCRIPTION
I propose setting the veins baseDir to the location of the launch config file (e.g. `veins_launchd.xml`) by default. It makes more sense to me, because there may be one config file for each scenario, which is where your OSM files should live that get referenced in the config.

This should make using multiple SUMO scenarios with the same networks easier, as you do not need to duplicate your networks, or maintain the baseDir XML tags. In my experience the latter became cumbersome in collaboration, because the basedir tag seemed to not work well with relative paths.

For standard projects, there should be no breaking change, as the network file resides in the same directory as the veins launch config by default.