### PR TITLE
Add support for 3D obstacles

### DIFF
--- a/src/veins/modules/obstacle/Obstacle.cc
+++ b/src/veins/modules/obstacle/Obstacle.cc
@@ -37,22 +37,56 @@ Obstacle::Obstacle(std::string id, std::string type, double attenuationPerCut, d
 {
 }
 
-void Obstacle::setShape(Coords shape)
+void Obstacle::setShape(Coords shape, double height )
 {
     coords = shape;
+    this-> height = height;
+    mesh = {};
     bboxP1 = Coord(1e7, 1e7);
     bboxP2 = Coord(-1e7, -1e7);
-    for (Coords::const_iterator i = coords.begin(); i != coords.end(); ++i) {
+    Coords::const_iterator i = coords.begin();
+    Coords::const_iterator j = i + 1;
+    for (; i != coords.end(); j = ++i + 1) {
         bboxP1.x = std::min(i->x, bboxP1.x);
         bboxP1.y = std::min(i->y, bboxP1.y);
         bboxP2.x = std::max(i->x, bboxP2.x);
         bboxP2.y = std::max(i->y, bboxP2.y);
+
+        if(height > 0 && j != coords.end())
+        {
+            // generating mesh for the walls
+            mesh.push_back({ Coord(i->x,i->y,0), Coord(i->x,i->y,height), Coord(j->x,j->y,height)});
+            mesh.push_back({ Coord(j->x,j->y,0), Coord(j->x,j->y,height), Coord(i->x,i->y,0)});
+
+        }
     }
+    
+    Coords shapeWithoutLast(shape.begin(), shape.end() - 1);
+    for(Coords monotonePolygon : partitionPolygonIntoMonotone(shapeWithoutLast))
+    {
+    	for(Triangle triangle : triangulateMonotonePolygon(monotonePolygon))
+    	{
+    		triangle.p1.z = 0;triangle.p2.z = 0;triangle.p3.z = 0;
+		    mesh.push_back(triangle);
+		    triangle.p1.z = height;triangle.p2.z = height;triangle.p3.z = height;
+		    mesh.push_back(triangle);
+    	}
+    }	
 }
 
 const Obstacle::Coords& Obstacle::getShape() const
 {
     return coords;
+}
+
+const Obstacle::Mesh& Obstacle::getMesh() const
+{
+    return mesh;
+}
+
+const double Obstacle::getHeight() const
+{
+    return height;
 }
 
 const Coord Obstacle::getBboxP1() const
@@ -68,6 +102,7 @@ const Coord Obstacle::getBboxP2() const
 bool Obstacle::containsPoint(Coord point) const
 {
     bool isInside = false;
+    if(point.z < 0 || (point.z > getHeight() && getHeight() > 0)) return false;
     const Obstacle::Coords& shape = getShape();
     Obstacle::Coords::const_iterator i = shape.begin();
     Obstacle::Coords::const_iterator j = (shape.rbegin() + 1).base();
@@ -85,7 +120,7 @@ bool Obstacle::containsPoint(Coord point) const
 
 namespace {
 
-double segmentsIntersectAt(const Coord& p1From, const Coord& p1To, const Coord& p2From, const Coord& p2To)
+double segmentsIntersectSegment(const Coord& p1From, const Coord& p1To, const Coord& p2From, const Coord& p2To) 
 {
     double p1x = p1To.x - p1From.x;
     double p1y = p1To.y - p1From.y;
@@ -103,23 +138,97 @@ double segmentsIntersectAt(const Coord& p1From, const Coord& p1To, const Coord& 
 
     return p1Frac;
 }
+
+/**
+ * Fast segment-triangle intersection test based on the
+ * Möller–Trumbore algorithm (1997).
+ *
+ * Uses barycentric coordinates to determine whether the segment pierces the
+ * triangle and returns the normalized intersection distance along the segment.
+ */
+double segmentsIntersectTriangle(const Segment& segment, const Triangle& triangle) 
+{
+    Coord edge1, edge2, segmentVector, h, s, q;
+    double a, f, u, v, t;
+
+    edge1.x = triangle.p2.x - triangle.p1.x;
+    edge1.y = triangle.p2.y - triangle.p1.y;
+    edge1.z = triangle.p2.z - triangle.p1.z;
+    edge2.x = triangle.p3.x - triangle.p1.x;
+    edge2.y = triangle.p3.y - triangle.p1.y;
+    edge2.z = triangle.p3.z - triangle.p1.z;
+    segmentVector.x = segment.p2.x - segment.p1.x;
+    segmentVector.y = segment.p2.y - segment.p1.y;
+    segmentVector.z = segment.p2.z - segment.p1.z;
+
+    h = computeCrossProduct(segmentVector,edge2);
+    a = computeDotProduct(edge1,h);
+
+    if (a > -0.00001 && a < 0.00001) {
+        return -1;
+    }
+
+    f = 1 / a;
+    s.x = segment.p1.x - triangle.p1.x;
+    s.y = segment.p1.y - triangle.p1.y;
+    s.z = segment.p1.z - triangle.p1.z;
+
+    u = f * computeDotProduct(s,h);
+
+    if (u < 0 || u > 1) {
+        return -1;
+    }
+
+    q = computeCrossProduct(s,edge1);
+    v = f * computeDotProduct(segmentVector,q);
+
+    if (v < 0 || u + v > 1) {
+        return -1;
+    }
+
+    t = f * computeDotProduct(edge2,q);
+
+    if (t > 0 && t < 1) {
+        return t;
+    }
+
+    return -1;
+}
+
 } // namespace
 
 std::vector<double> Obstacle::getIntersections(const Coord& senderPos, const Coord& receiverPos) const
 {
     std::vector<double> intersectAt;
-    const Obstacle::Coords& shape = getShape();
-    Obstacle::Coords::const_iterator i = shape.begin();
-    Obstacle::Coords::const_iterator j = (shape.rbegin() + 1).base();
-    for (; i != shape.end(); j = i++) {
-        const Coord& c1 = *i;
-        const Coord& c2 = *j;
 
-        double i = segmentsIntersectAt(senderPos, receiverPos, c1, c2);
-        if (i != -1) {
-            intersectAt.push_back(i);
+    if(getHeight() <= 0 )
+    {
+        const Obstacle::Coords& shape = getShape();
+        Obstacle::Coords::const_iterator i = shape.begin();
+        Obstacle::Coords::const_iterator j = (shape.rbegin() + 1).base();
+        for (; i != shape.end(); j = i++) {
+            const Coord& c1 = *i;
+            const Coord& c2 = *j;
+
+            double i = segmentsIntersectSegment(senderPos, receiverPos, c1, c2);
+            if (i != -1) {
+                intersectAt.push_back(i);
+            }
         }
     }
+    else
+    {
+        const Obstacle::Mesh& mesh = getMesh();
+        Obstacle::Mesh::const_iterator i = mesh.begin();
+        for (; i != mesh.end(); i++) {
+
+            double res = segmentsIntersectTriangle({senderPos, receiverPos}, *i);
+            if (res != -1) {
+                intersectAt.push_back(res);
+            }
+        }
+    }
+
     std::sort(intersectAt.begin(), intersectAt.end());
     return intersectAt;
 }

--- a/src/veins/modules/obstacle/Obstacle.h
+++ b/src/veins/modules/obstacle/Obstacle.h
@@ -28,6 +28,7 @@
 
 #include "veins/base/utils/Coord.h"
 #include "veins/modules/world/annotations/AnnotationManager.h"
+#include "veins/modules/obstacle/PolygonTriangulation.h"
 
 namespace veins {
 
@@ -37,11 +38,14 @@ namespace veins {
 class VEINS_API Obstacle {
 public:
     using Coords = std::vector<Coord>;
+    using Mesh = std::vector<Triangle>;
 
     Obstacle(std::string id, std::string type, double attenuationPerCut, double attenuationPerMeter);
 
-    void setShape(Coords shape);
+    void setShape(Coords shape, double height=0);
     const Coords& getShape() const;
+    const Mesh& getMesh() const;
+    const double getHeight() const;
     const Coord getBboxP1() const;
     const Coord getBboxP2() const;
     bool containsPoint(Coord Point) const;
@@ -64,6 +68,8 @@ protected:
     double attenuationPerCut; /**< in dB. attenuation per exterior border of obstacle */
     double attenuationPerMeter; /**< in dB / m. to account for attenuation caused by interior of obstacle */
     Coords coords;
+    double height;
+    Mesh mesh;
     Coord bboxP1;
     Coord bboxP2;
 };

--- a/src/veins/modules/obstacle/ObstacleControl.cc
+++ b/src/veins/modules/obstacle/ObstacleControl.cc
@@ -128,6 +128,8 @@ void ObstacleControl::addFromXml(cXMLElement* xml)
             ASSERT(e->getAttribute("shape"));
             std::string shape = e->getAttribute("shape");
 
+            double height = e->getAttribute("height") ?  std::stof(e->getAttribute("height")) : 0;
+
             Obstacle obs(id, type, getAttenuationPerCut(type), getAttenuationPerMeter(type));
             std::vector<Coord> sh;
             cStringTokenizer st(shape.c_str());
@@ -137,7 +139,7 @@ void ObstacleControl::addFromXml(cXMLElement* xml)
                 ASSERT(xya.size() == 2);
                 sh.push_back(Coord(xya[0], xya[1]));
             }
-            obs.setShape(sh);
+            obs.setShape(sh,height);
             add(obs);
         }
         else {
@@ -146,13 +148,17 @@ void ObstacleControl::addFromXml(cXMLElement* xml)
     }
 }
 
-void ObstacleControl::addFromTypeAndShape(std::string id, std::string typeId, std::vector<Coord> shape)
+void ObstacleControl::addFromTypeAndShape(std::string id, std::string typeId, std::vector<Coord> shape, double height)
 {
     if (!isTypeSupported(typeId)) {
         throw cRuntimeError("Unsupported obstacle type: \"%s\"", typeId.c_str());
     }
     Obstacle obs(id, typeId, getAttenuationPerCut(typeId), getAttenuationPerMeter(typeId));
-    obs.setShape(shape);
+    if(par("enable3d"))
+        obs.setShape(shape, height);
+    else
+        obs.setShape(shape, 0);
+
     add(obs);
 }
 

--- a/src/veins/modules/obstacle/ObstacleControl.h
+++ b/src/veins/modules/obstacle/ObstacleControl.h
@@ -53,7 +53,7 @@ public:
     void handleSelfMsg(cMessage* msg);
 
     void addFromXml(cXMLElement* xml);
-    void addFromTypeAndShape(std::string id, std::string typeId, std::vector<Coord> shape);
+    void addFromTypeAndShape(std::string id, std::string typeId, std::vector<Coord> shape,double height = 0.0);
     void add(Obstacle obstacle);
     void erase(const Obstacle* obstacle);
     bool isTypeSupported(std::string type);

--- a/src/veins/modules/obstacle/ObstacleControl.ned
+++ b/src/veins/modules/obstacle/ObstacleControl.ned
@@ -31,6 +31,7 @@ simple ObstacleControl
         @class(veins::ObstacleControl);
         xml obstacles = default(xml("<obstacles/>")); // list of obstacle types and obstacles to load
         int gridCellSize = default(250); // size of square grid tiles for obstacle store
+        bool enable3d = default(false);
         @display("i=misc/town");
         @labels(node);
 }

--- a/src/veins/modules/obstacle/PolygonTriangulation.cc
+++ b/src/veins/modules/obstacle/PolygonTriangulation.cc
@@ -1,0 +1,304 @@
+#include "veins/modules/obstacle/PolygonTriangulation.h"
+#include <utility>
+#include <math.h>
+#include <algorithm>
+#include <list>
+#include <map>
+#include <deque>
+
+using veins::Coord;
+using veins::Edge;
+using veins::vertexType;
+using veins::Triangle;
+
+// arc length between two indices in a cyclic array
+int veins::arc_length(int i, int j, int N) {
+    return std::min(std::abs(i - j), N - std::abs(i - j));
+}
+
+
+// finds the first edge over a given point
+const Edge* veins::findUpperBound(double y,double x, std::set<Edge> &bounds)
+{
+    std::set<Edge>::iterator it = bounds.begin();
+    while (it != bounds.end()) {
+        if (y < it->start.y + ((it->end.y - it->start.y) / (it->end.x - it->start.x)) * (x - it->start.x)) {
+            return &(*it);
+        }
+        ++it;
+    }
+
+    return nullptr;  
+}
+
+bool veins::isCounterClockwise(const std::vector<Coord>& vertices) {
+    double sum = 0.0;
+    size_t numVertices = vertices.size();
+
+    for (size_t i = 0; i < numVertices; ++i) {
+        const Coord& current = vertices[i];
+        const Coord& next = vertices[(i + 1) % numVertices]; 
+        sum += (next.x - current.x) * (next.y + current.y);
+    }
+
+    return sum > 0.0; 
+}
+
+vertexType veins::getVertexType(const Coord &vertex, const Coord &next, const Coord &prev )
+{
+    if(prev.x == vertex.x && vertex.x == next.x && prev.y > next.y)
+        return REGULAR_UPPER;
+    if(prev.x == vertex.x && vertex.x == next.x && prev.y < next.y)
+        return REGULAR_LOWER;
+    if(prev.x <= vertex.x && next.x < vertex.x )
+    {
+        Coord vector_pc = Coord(vertex.x - prev.x, vertex.y - prev.y, 0.0);
+        Coord vector_pn = Coord(next.x - prev.x, next.y - prev.y, 0.0);
+        double cross_product = vector_pc.x * vector_pn.y - vector_pc.y * vector_pn.x; 
+        
+        if(cross_product < 0)   return MERGE;
+        else                    return END;
+    }
+    
+    if(prev.x >= vertex.x && next.x > vertex.x )
+    {
+        Coord vector_pc = Coord(vertex.x - prev.x, vertex.y - prev.y, 0.0);
+        Coord vector_pn = Coord(next.x - prev.x, next.y - prev.y, 0.0);
+        double cross_product = vector_pc.x * vector_pn.y - vector_pc.y * vector_pn.x; 
+        
+        if(cross_product < 0)   return SPLIT;
+        else                    return START;
+    }
+    if( next.x <= vertex.x && vertex.x <= prev.x)   return REGULAR_UPPER;
+    if( next.x >= vertex.x && vertex.x >= prev.x)   return REGULAR_LOWER;
+}
+
+/*
+    sweep line algorithm to partition non monoton polygons in monotone polygons
+*/
+std::vector<std::vector<Coord>> veins::partitionPolygonIntoMonotone(std::vector<Coord>& polygon)
+{
+    bool isCCW = isCounterClockwise(polygon);
+    int vertices_num = polygon.size();
+    std::vector<Vertex> internalVertices(vertices_num);
+    for (size_t i = 0; i < vertices_num; ++i)
+    {
+        internalVertices[i].pos = polygon[i];
+        if(isCCW) internalVertices[i].pos.y = -internalVertices[i].pos.y;
+        internalVertices[i].index = i;
+        if(internalVertices[i].pos.x == polygon[(i+1)%vertices_num].x) internalVertices[i].pos.x += 0.000001;
+    }
+    
+    std::vector<Vertex> eventQueue = internalVertices;
+    std::sort(eventQueue.begin(), eventQueue.end());
+
+    // Sweep line partitions boundaries
+    std::set<Edge> activeEdges;
+
+    // vecotor of all monotone polygons found divided in upper and lower chains
+    std::vector<std::pair<std::vector<Coord>,std::vector<Coord>>> monotones;
+
+    for (const Vertex& ver : eventQueue)
+    {
+        Coord event = ver.pos;
+        Coord prev = internalVertices[(ver.index+vertices_num-1)%vertices_num].pos;
+        Coord next = internalVertices[(ver.index+1)%vertices_num].pos;
+
+        // Determine whether this is a merge vertex, split vertex, or regular vertex.
+        vertexType type = getVertexType(event, next, prev);
+
+        if (type == MERGE) 
+        {
+            const Edge* e = findUpperBound(event.y,event.x, activeEdges);
+
+            // if the last vertex seen in the upper polygon is a merge-vertex
+            if(e->getMergeMonotonePolygonIndex() != -1)
+                monotones[e->getMergeMonotonePolygonIndex()].first.push_back(event);
+
+            const Edge* e2 = &*activeEdges.find(Edge(event,next));
+
+            // if the last vertex seen in the lower polygon is a merge-vertex
+            if(e2->getMergeMonotonePolygonIndex() != -1)
+            {
+                e->setMergeMonotonePolygonIndex(e2->getMergeMonotonePolygonIndex());
+                monotones[e2->getMonotonePolygonIndex()].first.push_back(event);
+            }
+            else
+                e->setMergeMonotonePolygonIndex(e2->getMonotonePolygonIndex());
+
+            e->setHelper(event);
+            monotones[e->getMonotonePolygonIndex()].second.push_back(event);
+            monotones[e->getMergeMonotonePolygonIndex()].first.push_back(event);
+            activeEdges.erase(Edge(event,next));
+        }
+        else if (type == SPLIT) 
+        {
+            const Edge* e = findUpperBound(event.y,event.x, activeEdges);
+            if(e->getMergeMonotonePolygonIndex() == -1)
+            {
+                monotones.push_back(std::make_pair(std::vector<Coord>{*e->getHelper()}, std::vector<Coord>{}));
+                if(*e->getHelper() == e->start) // if the helper is in the upper-chain
+                {
+                    activeEdges.insert(Edge(prev,event,event,e->getMonotonePolygonIndex()));
+                    monotones[e->getMonotonePolygonIndex()].first.push_back(event);
+                    e->setMonotonePolygonIndex( monotones.size()-1);
+                    monotones[ e->getMonotonePolygonIndex()].second.push_back(event);
+                }
+                else                            // if the helper is in the lower-chain
+                {
+                    activeEdges.insert(Edge(prev,event,event,monotones.size()-1));
+                    monotones[e->getMonotonePolygonIndex()].second.push_back(event);
+                    monotones[monotones.size()-1].first.push_back(event);
+                }
+            }
+            else                                // if the helper is a previous merge-vertex
+            {
+                activeEdges.insert(Edge(prev,event,event, e->getMergeMonotonePolygonIndex()));
+                monotones[e->getMergeMonotonePolygonIndex()].first.push_back(event);
+                monotones[e->getMonotonePolygonIndex()].second.push_back(event);
+            }
+            
+            
+            e->setHelper(event);
+            e->setMergeMonotonePolygonIndex(-1);
+        }
+        else if(type == START) 
+        {
+            monotones.push_back(std::make_pair(std::vector<Coord>{event}, std::vector<Coord>{}));
+            activeEdges.insert(Edge(prev,event,event,monotones.size()-1));
+        }
+        else if(type == END) 
+        {
+            auto near = activeEdges.find(Edge(event,next));
+            if(near->getMergeMonotonePolygonIndex() != -1)
+            {
+                monotones[near->getMergeMonotonePolygonIndex()].second.push_back(event);
+                near->setMergeMonotonePolygonIndex(-1);
+            }
+            monotones[near->getMonotonePolygonIndex()].second.push_back(event);
+            activeEdges.erase(Edge(event,next)); 
+        }
+        else if (type == REGULAR_UPPER) 
+        {
+            const Edge* e = &(*activeEdges.find(Edge(event,next)));
+            if(e->getMergeMonotonePolygonIndex() != -1)
+            {
+                monotones[e->getMergeMonotonePolygonIndex()].first.push_back(event);
+                activeEdges.insert(Edge(event,prev,event,e->getMergeMonotonePolygonIndex()));
+                e->setMergeMonotonePolygonIndex(-1);
+            }
+            else
+                activeEdges.insert(Edge(event,prev,event,e->getMonotonePolygonIndex()));
+            monotones[e->getMonotonePolygonIndex()].first.push_back(event);
+            activeEdges.erase(Edge(event,next));
+        }
+        else if (type == REGULAR_LOWER) 
+        {
+            const Edge* e = findUpperBound(event.y,event.x, activeEdges);
+            if(e->getMergeMonotonePolygonIndex() != -1)
+            {
+                monotones[e->getMergeMonotonePolygonIndex()].second.push_back(event);
+                e->setMergeMonotonePolygonIndex(-1);
+            }
+            e->setHelper(event);
+            monotones[e->getMonotonePolygonIndex()].second.push_back(event);
+        }
+    }
+
+    std::vector<std::vector<Coord>> monotonePolygons;
+    for (auto m : monotones)
+    {
+        std::vector<Coord> newPol;
+        for (int i = m.first.size() - 1; i >= 0; --i)
+        {
+            if(isCCW) m.first[i].y = -m.first[i].y;
+            newPol.push_back(m.first[i]);
+        }
+        for (int i = 0 ; i < m.second.size(); ++i) 
+        {
+            if(isCCW) m.second[i].y = -m.second[i].y;
+            newPol.push_back(m.second[i]);
+        }
+        monotonePolygons.push_back(newPol);
+    }
+    return monotonePolygons;
+}
+
+int veins::DetermineConvexity(const Coord& p1, const Coord& p2, const Coord& p3)
+{
+    Coord v1 = {p2.x - p1.x, p2.y - p1.y, p2.z - p1.z};
+    Coord v2 = {p3.x - p1.x, p3.y - p1.y, p3.z - p1.z};
+
+    Coord cross = computeCrossProduct(v1,v2);
+    
+    if (cross.x > 0 || (cross.x == 0 && (cross.y > 0 || (cross.y == 0 && cross.z > 0))))
+        return 1;   // concave
+    else if (cross.x < 0 || (cross.x == 0 && (cross.y < 0 || (cross.y == 0 && cross.z < 0))))
+        return -1;  // convex
+    else
+        return 0;   // aligned
+}
+
+std::vector<Triangle> veins::triangulateMonotonePolygon(const std::vector<Coord>& polygon) {
+    std::vector<Triangle> triangles;
+    int poly_len = polygon.size();
+
+    if(poly_len < 3 ) return  std::vector<Triangle>();
+
+    std::vector<Vertex> eventQueue(poly_len);
+    for (size_t i = 0; i < poly_len; ++i) {
+        eventQueue[i].pos = polygon[i];
+        eventQueue[i].index = i;
+    }
+    std::sort(eventQueue.begin(), eventQueue.end());
+    std::deque<Vertex> deque;
+    deque.push_front(eventQueue[0]);
+    deque.push_front(eventQueue[1]);
+
+    bool isCCW = isCounterClockwise(polygon);
+    for (int i = 2; i < poly_len; ++i)
+    {
+        Vertex current = eventQueue[i];
+        Coord prev = polygon[(current.index + poly_len - 1) % poly_len];
+        Coord next = polygon[(current.index + 1) % poly_len];
+
+        Vertex last = deque.front();
+
+        vertexType lastType = getVertexType(last.pos, polygon[(last.index+1)%poly_len], polygon[(last.index+poly_len-1)%poly_len]);
+        vertexType type = getVertexType(current.pos,next,prev);
+
+        if(type == lastType)
+        {
+            deque.pop_front();
+            int convexity = DetermineConvexity(current.pos,last.pos,deque.front().pos);
+            while ( (( convexity < 0 && next.x < current.pos.x && current.pos.x < prev.x  && isCCW) || 
+                     ( convexity > 0 && next.x > current.pos.x && current.pos.x > prev.x  && isCCW) ||
+                     ( convexity < 0 && next.x > current.pos.x && current.pos.x > prev.x  && !isCCW) || 
+                     ( convexity > 0 && next.x < current.pos.x && current.pos.x < prev.x  && !isCCW)) && 
+                    deque.size() > 0)            
+            {
+                triangles.push_back({deque.front().pos,last.pos,current.pos});
+                last = deque.front();
+                deque.pop_front();
+                convexity = DetermineConvexity(current.pos,last.pos,deque.front().pos);
+            }
+            deque.push_front(last);
+            deque.push_front(current);
+        }
+        else
+        {
+            Coord tmp = deque.back().pos;
+            deque.pop_back();
+            while(deque.size() >= 2)
+            {
+                triangles.push_back({tmp,current.pos,deque.back().pos});
+                tmp = deque.back().pos;          
+                deque.pop_back();                
+            }
+            triangles.push_back({tmp,current.pos,deque.back().pos});
+            deque.push_front(current);
+        }   
+    }
+
+    return triangles;
+}

--- a/src/veins/modules/obstacle/PolygonTriangulation.h
+++ b/src/veins/modules/obstacle/PolygonTriangulation.h
@@ -1,0 +1,262 @@
+#include <vector>
+#include <set>
+#include "veins/base/utils/Coord.h"
+
+namespace veins {
+
+struct Triangle {
+    Coord p1;
+    Coord p2;
+    Coord p3;
+};
+
+struct Segment {
+    Coord p1;
+    Coord p2;
+};
+
+
+struct Vertex {
+    Coord pos;
+    int index;
+
+    bool operator<(const Vertex& other) const {
+        return pos.x < other.pos.x || (pos.x == other.pos.x && pos.y < other.pos.y);
+    }
+};
+
+inline Coord computeCrossProduct(const Coord& v1, const Coord& v2) {
+    return Coord(
+        v1.y * v2.z - v1.z * v2.y,
+        v1.z * v2.x - v1.x * v2.z,
+        v1.x * v2.y - v1.y * v2.x
+    );
+}
+
+inline double computeDotProduct(const Coord& v1, const Coord& v2) {
+    return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z;
+}
+
+/**
+ * @brief Class for storing edges of 2D polygons
+ *
+ * Some comparison and basic arithmetic operators are implemented.
+ *
+ */
+class VEINS_API Edge
+{
+private:
+    Coord* helper; // sweep line helper vertex
+    int* monotonePolygonIndex; // index of the relative monotone polygon  
+    int* mergeMonotonePolygonIndex; // index of the relative monotone polygon of the last seen merge vertex
+
+public:
+    Coord start;
+    Coord end;
+    
+    /** @brief Initializes an empty edge. */
+    Edge() {
+        helper = new Coord;
+        monotonePolygonIndex = new int(-1);
+        mergeMonotonePolygonIndex = new int(-1);
+    }
+
+    /** @brief Initializes an edge from the leftmost Coord to the righmost one, based on x position. */
+    Edge(const Coord& vertex1, const Coord& vertex2) : Edge() {
+        if (vertex1.x < vertex2.x) {
+            start = vertex1;
+            end = vertex2;
+        } else {
+            start = vertex2;
+            end = vertex1;
+        }
+    }
+
+    /** @brief Initializes an edge with another coordinate as a helper for the triangulation process. */
+    Edge(const Coord& vertex1, const Coord& vertex2, const Coord& help) : Edge(vertex1,vertex2) 
+    {    
+        *helper = help;
+    }
+    /** @brief Initializes an edge with a helper and the relative monotone polygon index for the triangulation process. */
+    Edge(const Coord& vertex1, const Coord& vertex2, const Coord& help, int index) : Edge(vertex1,vertex2,help) 
+    {    
+        *monotonePolygonIndex = index;
+    }
+
+    /** @brief Copy constructor for the Edge class */
+    Edge(const Edge& other)
+    {
+        start = other.start;
+        end = other.end;
+
+        helper = new Coord(*other.helper);
+        monotonePolygonIndex = new int(*other.monotonePolygonIndex);
+        mergeMonotonePolygonIndex = new int(*other.mergeMonotonePolygonIndex);
+    }
+
+    /**
+     * @brief Comparison operator for sorting edge events based on y-coordinate.
+     *
+     * This comparison operator is used to order Edge objects based on their y-coordinates,
+     * It ensures that when a collection of Edge objects is sorted using this operator,
+     * they will be arranged in increasing order of their y-coordinates.
+     * If two edges have the same y-coordinates, the operator considers their x-coordinates
+     *
+     * @param other The Edge object to compare against.
+     * @return True if this Edge should be placed before the 'other' Edge, otherwise False.
+     */
+    bool operator<(const Edge& other) const
+    {
+        if(this->start.x == other.start.x && this->end.x == other.end.x && 
+           this->start.y == other.start.y && this->end.y == other.end.y)
+            return false;
+        double thisMinY = std::min(start.y, end.y);
+        double thisMaxY = std::max(start.y, end.y);
+
+        double otherMinY = std::min(other.start.y, other.end.y);
+        double otherMaxY = std::max(other.start.y, other.end.y);
+        if (thisMaxY <= otherMinY) {
+            return true;
+        } else if (thisMinY >= otherMaxY) {
+            return false;
+        } else {
+            return start.y < other.start.y;
+        }
+    }
+
+    bool operator==(const Edge& other) const {
+        return start == other.start && end == other.end;
+    }
+
+    bool operator!=(const Edge& other) const {
+        return !(*this == other);
+    }
+    
+    Coord* getHelper() const {
+        return helper;
+    }
+
+    void setHelper(const Coord& newHelper) const {
+        *helper = newHelper;
+    }
+
+    int getMonotonePolygonIndex() const {
+        return *monotonePolygonIndex;
+    }
+
+    void setMonotonePolygonIndex(int newIndex) const {
+        *monotonePolygonIndex = newIndex;
+    }
+
+    int getMergeMonotonePolygonIndex() const {
+        return *mergeMonotonePolygonIndex;
+    }
+
+    void setMergeMonotonePolygonIndex(int newIndex) const {
+        *mergeMonotonePolygonIndex = newIndex;
+    }
+
+    ~Edge() {
+        delete helper;
+        delete monotonePolygonIndex;
+        delete mergeMonotonePolygonIndex;
+    }
+
+};
+
+/** @brief Calculate arc length between two indices in a cyclic array */
+int arc_length(int i, int j, int N);
+
+
+/**
+ * @brief Enumeration of vertex types used in polygon processing.
+ *
+ * This enumeration defines various types of vertices encountered during polygon processing,
+ * such as triangulation and partitioning. 
+ */
+enum vertexType { START, END, MERGE, SPLIT, REGULAR_UPPER, REGULAR_LOWER, VERTICAL };
+
+
+/**
+ * @brief Finds the upper bound of an Edge in a set based on y-coordinate and x-coordinate.
+ *
+ * This function searches for the upper bound of an Edge object within a set of Edge objects
+ * based on their y-coordinates and, if necessary, their x-coordinates. It returns a pointer
+ * to the located Edge object. The set is expected to be sorted using the < operator defined
+ * for Edge objects, with y-coordinates taking priority and x-coordinates breaking ties.
+ *
+ * @param y The y-coordinate to search for.
+ * @param x The x-coordinate to further refine the search.
+ * @param bounds The set of Edge objects to search within.
+ * @return A pointer to the upper bound Edge in the set.
+ */
+const Edge* findUpperBound(double y, double x, std::set<Edge>& bounds);
+
+/**
+ * @brief Partitions a polygon into monotone sub-polygons.
+ *
+ * This function takes a polygon represented by a vector of Coord vertices and partitions it
+ * into monotone sub-polygons. 
+ * The function returns a vector of vectors of Coord, where each sub-vector
+ * represents a monotone sub-polygon.
+ *
+ * @param polygon The input polygon to be partitioned.
+ * @return A vector of monotone sub-polygons' vertices.
+ */
+std::vector<std::vector<Coord>> partitionPolygonIntoMonotone(std::vector<Coord>& polygon);
+
+/**
+ * @brief Triangulates a monotone polygon into triangles.
+ *
+ * Given a monotone polygon represented by a vector of Coord vertices, this function
+ * triangulates the polygon into triangles. The input polygon is assumed to be monotone,
+ * and the function returns a vector of Triangle objects representing the resulting triangles.
+ *
+ * @param polygon The monotone polygon to be triangulated.
+ * @return A vector of Triangle objects forming the triangulation.
+ */
+std::vector<Triangle> triangulateMonotonePolygon(const std::vector<Coord>& polygon);
+
+/**
+ * @brief Determines the type of a vertex in relation to its neighbors.
+ *
+ * This function categorizes a vertex within a polygon based on its position and orientation
+ * relative to its neighboring vertices. The vertex can be classified as START, END, SPLIT, MERGE,
+ * or REGULAR based on its local configuration.
+ *
+ * @param vertex The vertex to classify.
+ * @param next The next vertex in polygon traversal order.
+ * @param prev The previous vertex in polygon traversal order.
+ * @return The type of the vertex (START, END, SPLIT, MERGE, or REGULAR).
+ */
+vertexType getVertexType(const Coord& vertex, const Coord& next, const Coord& prev);
+
+/**
+ * @brief Checks if a polygon is oriented in counter-clockwise direction.
+ *
+ * This function determines whether a polygon represented by a vector of Coord vertices
+ * is oriented in a counter-clockwise direction. It applies the "shoelace formula" to calculate
+ * the signed area of the polygon and uses its sign to determine orientation.
+ *
+ * @param vertices The vertices of the polygon.
+ * @return True if the polygon is counter-clockwise, False otherwise.
+ */
+bool isCounterClockwise(const std::vector<Coord>& vertices);
+
+
+/**
+ * @brief Determines the convexity of three points.
+ *
+ * This function assesses the convexity of three points
+ * It calculates the cross product of the vectors formed by p2 - p1 and p3 - p1 to determine the
+ * orientation of the points. The function returns 1 if the points form a concave curve, -1 if they
+ * form a convex curve, and 0 if the points are aligned.
+ *
+ * @param p1 The first point.
+ * @param p2 The second point.
+ * @param p3 The third point.
+ * @return  1 if concave, -1 if convex, 0 if aligned.
+ */
+int DetermineConvexity(const Coord& p1, const Coord& p2, const Coord& p3);
+
+} // namespace veins


### PR DESCRIPTION
The code adds support for 3D obstacles. It allows the generation of simple 3D meshes for obstacles when a height is provided together with the polygon shape of the obstacle.

The 2D polygon footprints are extruded to form the 3D building meshes. 
The triangulation algorithm is used to obtain the base and the roof of the buildings.

Signal attenuation and intersections with 3D obstacles are computed using the Möller–Trumbore ray-triangle algorithm.
The code does not alter how standard 2D intersections are found.
The feature can be controlled by a flag in ObstacleControl.ned (defaults to false) and it doesn't affect existing 2D simulations.